### PR TITLE
Fix builder pathing oscillation (#39)

### DIFF
--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1613,3 +1613,28 @@ Prevention (write clean first) > Cleanup (fix lint errors post-merge).
 Valid exceptions (e.g., E2E browser-context code) require documented decision in decisions.md.
 
 See: 2026-03-08: ESLint Override for E2E Browser Context Code
+
+---
+
+### Session: Fix Builder Pathing Oscillation (#39)
+
+**Date:** 2026-07-25
+**PR:** #55 (squad/39-fix-builder-pathing → dev)
+**Issue:** #39
+
+**Root Cause:** Built tiles get `shapeHP = BLOCK_HP` (100), and `isWalkable()` returns `false` for `shapeHP > 0`. Builders' own outposts became walls for the greedy `moveToward()` pathfinder, causing oscillation when targets were behind a wall of structures.
+
+**Fix (3 parts):**
+1. `isTileOpenForCreature` — builders can now traverse structures on their own territory
+2. `findBuildSite` — outward expansion bias (prefer tiles further from HQ among equal-distance candidates)
+3. `move_to_site` — if `moveToward()` fails, abandon target and re-scan (stuck detection)
+
+**Key Files:**
+- `server/src/rooms/builderAI.ts` — Builder FSM and site selection
+- `server/src/rooms/creatureAI.ts` — Movement and tile access checks
+- `server/src/rooms/GameState.ts` — `isWalkable()` blocks on `shapeHP > 0`
+
+**Learnings:**
+4. **shapeHP blocks movement** — Any tile with `shapeHP > 0` is unwalkable via `isWalkable()`. Builder-created structures (outposts, farms) get `BLOCK_HP`. This creates implicit walls. Any new structure type must consider pathfinding impact.
+5. **Greedy pathfinder limitation** — `moveToward()` is a 1-step greedy Manhattan mover with no memory. It oscillates when blocked by walls. A* (Phase 5) will fix this properly, but until then, creature-specific traversal rules and stuck detection are the mitigation.
+6. **findBuildSite scan order bias** — The nested dy/dx loop in `findBuildSite` creates a top-left bias for equal-distance candidates. The HQ-distance tiebreaker now overrides this to prefer outward expansion.

--- a/.squad/decisions/inbox/pemulis-builder-pathing.md
+++ b/.squad/decisions/inbox/pemulis-builder-pathing.md
@@ -1,0 +1,23 @@
+# Decision: Builders Traverse Own Structures
+
+**Date:** 2026-07-25
+**Author:** Pemulis (Systems Dev)
+**Context:** Fix for #39 — builder pathing oscillation
+
+## Decision
+
+Builders (pawn_builder) can now walk through structures (`shapeHP > 0`) on their owner's territory. This is implemented in `isTileOpenForCreature()` in `creatureAI.ts`.
+
+**Only builders** get this traversal — defenders, attackers, wildlife, and enemy units are still blocked by structures as before.
+
+## Rationale
+
+Built outpost/farm tiles get `shapeHP = BLOCK_HP` (100), which makes them unwalkable. Builders creating a line of outposts would wall themselves off from frontier tiles. The greedy pathfinder (`moveToward`) can't navigate around these walls, causing oscillation.
+
+Allowing builders through their own structures is gameplay-appropriate (construction units navigate their own constructions) and doesn't affect combat balance (attackers/enemies still blocked).
+
+## Impact
+
+- **Gately (Game Dev):** Builder movement tests may need updating if they assumed builders are blocked by own structures.
+- **Combat:** No impact. Attackers/defenders/enemies still blocked by structures.
+- **Phase 5 (A*):** When A* replaces the greedy pathfinder, this traversal rule should be preserved so builders can still path through their own territory efficiently.

--- a/server/src/rooms/builderAI.ts
+++ b/server/src/rooms/builderAI.ts
@@ -37,7 +37,13 @@ export function stepBuilder(creature: CreatureState, state: GameState): void {
         creature.currentState = "building";
         creature.buildProgress = 0;
       } else {
-        moveToward(creature, creature.targetX, creature.targetY, state);
+        const moved = moveToward(creature, creature.targetX, creature.targetY, state);
+        if (!moved) {
+          // Path blocked — abandon target and re-scan next tick
+          creature.targetX = -1;
+          creature.targetY = -1;
+          creature.currentState = "idle";
+        }
       }
       break;
     }
@@ -112,16 +118,19 @@ function isValidBuildTile(tile: { type: number; shapeHP: number }): boolean {
 }
 
 /**
- * Find the nearest unclaimed walkable tile adjacent to the builder's owner's territory.
+ * Find the best unclaimed walkable tile adjacent to the builder's owner's territory.
  * Scans within BUILD_SITE_SCAN_RADIUS.
+ * Prefers closest tiles, with a tiebreaker favoring outward expansion (further from HQ).
  */
 function findBuildSite(
   creature: CreatureState,
   state: GameState,
 ): { x: number; y: number } | null {
   const radius = PAWN.BUILD_SITE_SCAN_RADIUS;
+  const player = state.players.get(creature.ownerID);
   let best: { x: number; y: number } | null = null;
   let bestDist = Infinity;
+  let bestHqDist = -1;
 
   for (let dy = -radius; dy <= radius; dy++) {
     for (let dx = -radius; dx <= radius; dx++) {
@@ -134,8 +143,16 @@ function findBuildSite(
       if (!isAdjacentToTerritory(state, creature.ownerID, tx, ty)) continue;
 
       const dist = Math.abs(dx) + Math.abs(dy);
-      if (dist > 0 && dist < bestDist) {
+      if (dist === 0) continue;
+
+      // Among equal-distance candidates, prefer tiles further from HQ (outward expansion)
+      const hqDist = player
+        ? Math.abs(tx - player.hqX) + Math.abs(ty - player.hqY)
+        : 0;
+
+      if (dist < bestDist || (dist === bestDist && hqDist > bestHqDist)) {
         bestDist = dist;
+        bestHqDist = hqDist;
         best = { x: tx, y: ty };
       }
     }

--- a/server/src/rooms/creatureAI.ts
+++ b/server/src/rooms/creatureAI.ts
@@ -392,7 +392,16 @@ function findNearestResource(
  * - Wildlife (herbivores, carnivores) cannot enter owned tiles
  */
 export function isTileOpenForCreature(state: GameState, creature: CreatureState, x: number, y: number): boolean {
-  if (!state.isWalkable(x, y)) return false;
+  if (!state.isWalkable(x, y)) {
+    // Builders can traverse their own structures (outposts, farms)
+    if (creature.creatureType === "pawn_builder") {
+      const tile = state.getTile(x, y);
+      if (tile && tile.shapeHP > 0 && tile.ownerID === creature.ownerID) {
+        return true;
+      }
+    }
+    return false;
+  }
   const tile = state.getTile(x, y);
   if (!tile) return false;
 


### PR DESCRIPTION
Closes #39

Working as Pemulis (Systems Dev)

## Root Cause

When a builder builds a tile, it sets `shapeHP = BLOCK_HP` (100). `isWalkable()` returns `false` for any tile with `shapeHP > 0`. This means **built outpost tiles become walls** for the greedy `moveToward()` pathfinder. After building a line of outposts, the builder targets tiles on the other side of its own structures and the greedy pathfinder oscillates between two positions trying to get through.

A secondary issue: `findBuildSite()` used pure Manhattan distance with no directional preference, so after building a frontier tile, the nearest unclaimed tile might be in the opposite direction, causing the builder to backtrack.

## Fix (3 parts)

1. **Builder structure traversal** (`creatureAI.ts`): In `isTileOpenForCreature`, builders can now walk through structures (`shapeHP > 0`) on their own territory. Other pawns and wildlife are unaffected.

2. **Outward expansion bias** (`builderAI.ts`): `findBuildSite()` now breaks ties among equal-distance candidates by preferring tiles further from the player's HQ. Builders push territory outward instead of filling interior gaps.

3. **Stuck detection** (`builderAI.ts`): If `moveToward()` fails in `move_to_site` state (all directions blocked), the builder abandons its target and re-scans next tick instead of silently staying stuck.

## Testing

All 520 existing tests pass. The changes are surgical — only builder movement is affected; no other creature types or combat behavior changed.