### PR TITLE
fix: remove territory column from scoreboard

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -356,7 +356,7 @@
       <div id="scoreboard-panel">
         <h2>🏆 Scoreboard</h2>
         <table id="scoreboard-table">
-          <thead><tr><th>Player</th><th>Score</th><th>Territory</th></tr></thead>
+          <thead><tr><th>Player</th><th>Score</th></tr></thead>
           <tbody id="scoreboard-body"></tbody>
         </table>
         <div id="scoreboard-hint">Press Tab to close</div>

--- a/client/src/ui/Scoreboard.ts
+++ b/client/src/ui/Scoreboard.ts
@@ -54,20 +54,6 @@ export class Scoreboard {
       | undefined;
     if (!players || typeof players.forEach !== 'function') return;
 
-    // Count territory tiles per player
-    const territoryCounts = new Map<string, number>();
-    const tiles = state['tiles'] as
-      | { forEach: (cb: (t: Record<string, unknown>) => void) => void }
-      | undefined;
-    if (tiles && typeof tiles.forEach === 'function') {
-      tiles.forEach((tile: Record<string, unknown>) => {
-        const ownerID = (tile['ownerID'] as string) ?? '';
-        if (ownerID !== '') {
-          territoryCounts.set(ownerID, (territoryCounts.get(ownerID) ?? 0) + 1);
-        }
-      });
-    }
-
     const rows: PlayerRow[] = [];
     players.forEach((player: Record<string, unknown>, key: string) => {
       const id = (player['id'] as string) ?? key;
@@ -94,20 +80,6 @@ export class Scoreboard {
       const tdScore = document.createElement('td');
       tdScore.textContent = String(row.score);
       tr.appendChild(tdScore);
-
-      // Look up territory count by finding the player's real ID (strip " (you)" suffix)
-      const cleanName = row.name.replace(' (you)', '');
-      let territory = 0;
-      players.forEach((player: Record<string, unknown>, key: string) => {
-        const id = (player['id'] as string) ?? key;
-        const pName = (player['displayName'] as string) || 'Player';
-        if (pName === cleanName || row.name === `${pName} (you)`) {
-          territory = territoryCounts.get(id) ?? 0;
-        }
-      });
-      const tdTerritory = document.createElement('td');
-      tdTerritory.textContent = String(territory);
-      tr.appendChild(tdTerritory);
 
       this.tbody.appendChild(tr);
     }


### PR DESCRIPTION
## Summary

Removes the **Territory** column from the scoreboard overlay. Territory data is private per-player state and should not be visible to other players.

### Changes
- **`client/index.html`** — Removed `<th>Territory</th>` from the scoreboard table header.
- **`client/src/ui/Scoreboard.ts`** — Removed territory tile counting logic (`territoryCounts` map, tile iteration, player-ID reverse-lookup) and the `<td>` cell that displayed territory count per row.

### What's kept
- The HUD's own territory count (`#territory-count-val`) is unchanged — that shows the *local* player their own tile count, which is fine.
- Scoreboard still shows Player name (with color) and Score columns.

### Testing
- TypeScript compiles cleanly (`tsc --noEmit`)
- ESLint passes (`npm run lint`)
- E2E scoreboard tests (`join-flow.spec.ts`) don't reference the territory column — no test changes needed.

Closes #38

Working as Gately (Game Dev / Frontend Rendering)