### PR TITLE
Merge dev → uat: Gameplay fixes & PR review feedback

### DIFF
--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1641,7 +1641,7 @@ See: 2026-03-08: ESLint Override for E2E Browser Context Code
 
 ### Session: UAT Gameplay Fixes — Enemy Camps, Builder Gaps, Upkeep Removal
 
-**Date:** $(date +%Y-%m-%d)
+**Date:** 2026-03-08
 **Branch:** dev
 **Issues:** 3 UAT-reported gameplay bugs
 

--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1638,3 +1638,44 @@ See: 2026-03-08: ESLint Override for E2E Browser Context Code
 4. **shapeHP blocks movement** — Any tile with `shapeHP > 0` is unwalkable via `isWalkable()`. Builder-created structures (outposts, farms) get `BLOCK_HP`. This creates implicit walls. Any new structure type must consider pathfinding impact.
 5. **Greedy pathfinder limitation** — `moveToward()` is a 1-step greedy Manhattan mover with no memory. It oscillates when blocked by walls. A* (Phase 5) will fix this properly, but until then, creature-specific traversal rules and stuck detection are the mitigation.
 6. **findBuildSite scan order bias** — The nested dy/dx loop in `findBuildSite` creates a top-left bias for equal-distance candidates. The HQ-distance tiebreaker now overrides this to prefer outward expansion.
+
+### Session: UAT Gameplay Fixes — Enemy Camps, Builder Gaps, Upkeep Removal
+
+**Date:** $(date +%Y-%m-%d)
+**Branch:** dev
+**Issues:** 3 UAT-reported gameplay bugs
+
+**Fix 1 — Enemy Camps in Player Territory:**
+Added territorial radius check (Manhattan dist 5) to `findEnemyBaseSpawnLocation()`. Candidate tiles are now rejected if ANY tile within radius has an ownerID.
+
+**Fix 2 — Builder Interior Gaps:**
+`findBuildSite()` now detects interior gaps (unowned tiles with 3+ cardinal neighbors owned by player) and prioritizes filling those before outward expansion. Outward bias retained as secondary tiebreaker.
+
+**Fix 3 — Remove Pawn Wood Upkeep:**
+Removed `tickPawnUpkeep()` method, game loop call, `upkeep` field from `PawnTypeDef`/`PAWN_TYPES`, and upkeep constants (`BUILDER_UPKEEP_WOOD`, `UPKEEP_INTERVAL_TICKS`, `UPKEEP_DAMAGE`). Removed 8 upkeep tests across pawnBuilder, combat-system, and gameLog test files.
+
+**Learnings:**
+7. **Interior gap detection pattern** — Checking 3+ cardinal neighbors with same ownerID reliably identifies territory holes. This pattern can be reused for territory health/completeness scoring.
+8. **Territorial exclusion zones** — Manhattan-distance radius checks around spawn candidates are cheap and effective for keeping spawns away from player influence. Radius of 5 is a good baseline for 128x128 maps.
+
+---
+
+### Session: UAT Gameplay Fixes — Enemy Camps, Builder Gaps, Upkeep Removal (Completed)
+
+**Date:** 2026-03-08
+**Branch:** dev
+**Commits:**
+- 69c3f39: fix: add territorial radius check to enemy base spawn location
+- 7c443c4: fix: prioritize interior gaps over outward expansion in builder AI
+- c80d898: feat: remove wood upkeep system for all pawns
+
+**Status:** SUCCESS
+- 3 UAT-reported gameplay bugs fixed
+- 515 tests passing
+- Lint clean
+- All work committed to dev
+
+**Key Implementation Patterns Documented:**
+- Territorial exclusion zones via Manhattan-distance radius checks
+- Interior gap detection using cardinal neighbor counts
+- Systematic removal of deprecated game mechanics

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -5133,3 +5133,35 @@ File: `server/src/index.ts`
 - **Testing:** No new tests required (logging enhancement)
 
 ---
+
+## Remove Pawn Wood Upkeep System
+
+**Date:** 2026-03-08
+**Author:** Pemulis (Systems Dev)
+**Status:** IMPLEMENTED
+
+### Decision
+
+Wood upkeep for pawns (builders, defenders, attackers) has been completely removed as a gameplay mechanic. Pawns no longer consume wood to stay alive and no longer take damage or die from upkeep failure.
+
+### What Changed
+
+- `tickPawnUpkeep()` removed from GameRoom and game loop
+- `upkeep` field removed from `PawnTypeDef` interface and all `PAWN_TYPES` entries
+- `BUILDER_UPKEEP_WOOD`, `UPKEEP_INTERVAL_TICKS`, `UPKEEP_DAMAGE` constants removed from `PAWN`
+- 8 upkeep tests removed (pawnBuilder, combat-system, gameLog)
+- Client-side `upkeep` log type config left intact (harmless, no events sent)
+
+### What's NOT Affected
+
+- Wild creature hunger system (herbivores/carnivores)
+- Wood as building resource
+- Any other resource mechanics
+
+### Impact
+
+- **Balance:** Pawns are now permanent once spawned (until killed). Economy pressure from wood upkeep is gone — may need rebalancing elsewhere.
+- **Client:** `GameLog.ts` still has `upkeep` type styling — can be cleaned up later if desired.
+- **Tests:** 515 tests passing after removal.
+
+---

--- a/server/src/__tests__/combat-system.test.ts
+++ b/server/src/__tests__/combat-system.test.ts
@@ -36,7 +36,7 @@ type TestableGameRoom = GameRoom & {
   attackerState: Map<string, AttackerTracker>;
   tickEnemyBaseSpawning(): void;
   handleSpawnPawn(client: { sessionId: string; send: (...args: unknown[]) => void }, message: { pawnType: string }): void;
-  tickPawnUpkeep(): void;
+
 };
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -902,11 +902,10 @@ describe("Pawn Types — Constants & Registry", () => {
     expect(PAWN_TYPES["attacker"].cost.stone).toBeGreaterThan(PAWN_TYPES["defender"].cost.stone);
   });
 
-  it("each pawn type has damage, HP, maxCount, and upkeep defined", () => {
+  it("each pawn type has damage, HP, and maxCount defined", () => {
     for (const [_key, def] of Object.entries(PAWN_TYPES)) {
       expect(def.health).toBeGreaterThan(0);
       expect(def.maxCount).toBeGreaterThan(0);
-      expect(def.upkeep).toBeDefined();
       expect(typeof def.damage).toBe("number");
     }
   });

--- a/server/src/__tests__/combat-system.test.ts
+++ b/server/src/__tests__/combat-system.test.ts
@@ -21,7 +21,7 @@ import type { AttackerTracker } from "../rooms/attackerAI.js";
 import {
   ENEMY_BASE_TYPES, ENEMY_MOBILE_TYPES, PAWN_TYPES,
   COMBAT, ENEMY_SPAWNING, SHAPE,
-  PAWN, TERRITORY,
+  TERRITORY,
   DayPhase,
   isEnemyBase, isEnemyMobile,
 } from "@primal-grid/shared";
@@ -1478,83 +1478,6 @@ describe("Attackers — Seek & Destroy AI", () => {
 
     // Should re-seek
     expect(atk.currentState).toBe("seek_target");
-  });
-});
-
-// ── 2.7  Pawn Upkeep — Defenders & Attackers ─────────────────────────
-
-describe("Pawn Upkeep — Defenders & Attackers", () => {
-  it("defender incurs upkeep cost each UPKEEP_INTERVAL_TICKS", () => {
-    const room = createRoom();
-    const player = joinPlayer(room, "p1");
-    player.wood = 100;
-
-    addDefender(room, "upkeep-def", "p1", player.hqX, player.hqY);
-
-    room.state.tick = PAWN.UPKEEP_INTERVAL_TICKS;
-    room.tickPawnUpkeep();
-
-    const defUpkeep = PAWN_TYPES["defender"].upkeep.wood;
-    expect(player.wood).toBe(100 - defUpkeep);
-  });
-
-  it("attacker incurs upkeep cost each UPKEEP_INTERVAL_TICKS", () => {
-    const room = createRoom();
-    const player = joinPlayer(room, "p1");
-    player.wood = 100;
-
-    addAttacker(room, "upkeep-atk", "p1", player.hqX, player.hqY);
-
-    room.state.tick = PAWN.UPKEEP_INTERVAL_TICKS;
-    room.tickPawnUpkeep();
-
-    const atkUpkeep = PAWN_TYPES["attacker"].upkeep.wood;
-    expect(player.wood).toBe(100 - atkUpkeep);
-  });
-
-  it("defender takes damage if player cannot afford upkeep", () => {
-    const room = createRoom();
-    const player = joinPlayer(room, "p1");
-    player.wood = 0;
-
-    const def = addDefender(room, "broke-def", "p1", player.hqX, player.hqY);
-    const origHP = def.health;
-
-    room.state.tick = PAWN.UPKEEP_INTERVAL_TICKS;
-    room.tickPawnUpkeep();
-
-    expect(def.health).toBe(origHP - PAWN.UPKEEP_DAMAGE);
-  });
-
-  it("attacker takes damage if player cannot afford upkeep", () => {
-    const room = createRoom();
-    const player = joinPlayer(room, "p1");
-    player.wood = 0;
-
-    const atk = addAttacker(room, "broke-atk", "p1", player.hqX, player.hqY);
-    const origHP = atk.health;
-
-    room.state.tick = PAWN.UPKEEP_INTERVAL_TICKS;
-    room.tickPawnUpkeep();
-
-    expect(atk.health).toBe(origHP - PAWN.UPKEEP_DAMAGE);
-  });
-
-  it("pawn dies from accumulated upkeep damage when resources stay at zero", () => {
-    const room = createRoom();
-    const player = joinPlayer(room, "p1");
-    player.wood = 0;
-
-    const _def = addDefender(room, "starve-def", "p1", player.hqX, player.hqY);
-
-    // Enough upkeep ticks to kill the defender
-    const ticksToKill = Math.ceil(PAWN_TYPES["defender"].health / PAWN.UPKEEP_DAMAGE);
-    for (let i = 1; i <= ticksToKill; i++) {
-      room.state.tick = PAWN.UPKEEP_INTERVAL_TICKS * i;
-      room.tickPawnUpkeep();
-    }
-
-    expect(room.state.creatures.has("starve-def")).toBe(false);
   });
 });
 

--- a/server/src/__tests__/gameLog.test.ts
+++ b/server/src/__tests__/gameLog.test.ts
@@ -128,16 +128,6 @@ function tickAI(room: TestGameRoom): void {
   if (typeof room.tickCreatureAI === "function") room.tickCreatureAI();
 }
 
-/** Tick upkeep system once at the given cycle number. */
-function tickUpkeep(room: TestGameRoom, cycle: number): void {
-  room.state.tick = PAWN.UPKEEP_INTERVAL_TICKS * cycle;
-  if (typeof room.tickPawnUpkeep === "function") {
-    room.tickPawnUpkeep();
-  } else if (typeof room.tickCreatureAI === "function") {
-    room.tickCreatureAI();
-  }
-}
-
 /** Collect all broadcast calls matching a given message type. */
 function getLogBroadcasts(room: TestGameRoom, logType?: string): GameLogPayload[] {
   return room.broadcast.mock.calls
@@ -234,69 +224,7 @@ describe("Game Log Events", () => {
     });
   });
 
-  // ── 3. Upkeep damage → "upkeep" event ───────────────────────────
-
-  describe("builder upkeep warning", () => {
-    it("builder upkeep damage sends game_log upkeep event", () => {
-      const room = createRoomWithMap(42);
-      const { player } = joinPlayer(room, "p1");
-
-      player.wood = 0;
-      const pos = findWalkableTile(room);
-      addBuilder(room, "b-hungry", "p1", pos.x, pos.y, {
-        health: PAWN.BUILDER_HEALTH,
-      });
-
-      const healthBefore = PAWN.BUILDER_HEALTH;
-      tickUpkeep(room, 1);
-
-      // Verify state precondition: builder took upkeep damage
-      const builder = room.state.creatures.get("b-hungry");
-      expect(builder).toBeDefined();
-      expect(builder!.health).toBeLessThan(healthBefore);
-
-      // Verify game_log broadcast with type "upkeep"
-      // TODO: This assertion will pass once Pemulis lands upkeep event broadcasting in tickPawnUpkeep
-      const upkeepLogs = getLogBroadcasts(room, "upkeep");
-      expect(upkeepLogs.length).toBeGreaterThanOrEqual(1);
-      expect(upkeepLogs[0]).toMatchObject({
-        type: "upkeep",
-        message: expect.any(String),
-      });
-    });
-  });
-
-  // ── 4. Builder death from upkeep → "death" event ────────────────
-
-  describe("builder death from upkeep", () => {
-    it("builder death from upkeep sends game_log death event", () => {
-      const room = createRoomWithMap(42);
-      const { player } = joinPlayer(room, "p1");
-
-      player.wood = 0;
-      const pos = findWalkableTile(room);
-      // Health less than UPKEEP_DAMAGE so one tick kills it
-      addBuilder(room, "b-starve", "p1", pos.x, pos.y, {
-        health: PAWN.UPKEEP_DAMAGE - 1,
-      });
-
-      tickUpkeep(room, 1);
-
-      // Verify state precondition: builder is dead
-      expect(room.state.creatures.has("b-starve")).toBe(false);
-
-      // Verify game_log broadcast with type "death"
-      // TODO: This assertion will pass once Pemulis lands death event broadcasting in tickPawnUpkeep
-      const deathLogs = getLogBroadcasts(room, "death");
-      expect(deathLogs.length).toBeGreaterThanOrEqual(1);
-      expect(deathLogs[0]).toMatchObject({
-        type: "death",
-        message: expect.any(String),
-      });
-    });
-  });
-
-  // ── 5. Player join → "info" event (sent to joining client) ──────
+  // ── 3. Player join → "info" event (sent to joining client) ──────
 
   describe("player join info event", () => {
     it("player joining sends game_log info event to that client", () => {

--- a/server/src/__tests__/pawnBuilder.test.ts
+++ b/server/src/__tests__/pawnBuilder.test.ts
@@ -159,18 +159,6 @@ function tickAI(room: GameRoom): void {
   }
 }
 
-/** Tick upkeep system once at the given cycle number. */
-function tickUpkeep(room: GameRoom, cycle: number): void {
-  room.state.tick = PAWN.UPKEEP_INTERVAL_TICKS * cycle;
-  if (typeof room.tickPawnUpkeep === "function") {
-    room.tickPawnUpkeep();
-  } else if (typeof room.tickBuilderAI === "function") {
-    room.tickBuilderAI();
-  } else {
-    room.tickCreatureAI();
-  }
-}
-
 /** Manhattan distance. */
 function manhattan(x1: number, y1: number, x2: number, y2: number): number {
   return Math.abs(x1 - x2) + Math.abs(y1 - y2);
@@ -499,60 +487,6 @@ describe("Adjacency validation (prevent teleport builds)", () => {
     for (let i = 0; i < 3; i++) tickAI(room);
 
     expect(["idle", "find_build_site", "move_to_site", "building"]).toContain(builder.currentState);
-  });
-});
-
-// ═════════════════════════════════════════════════════════════════════
-// Category 4 — Upkeep system (resource drain, frequency)           3
-// ═════════════════════════════════════════════════════════════════════
-
-describe("Upkeep system (resource drain, frequency)", () => {
-
-  it("upkeep deducts 1 Wood per builder each 60-tick cycle", () => {
-    const room = createRoomWithMap(42);
-    const { player } = joinPlayer(room, "p1");
-
-    player.wood = 20;
-    const pos = findWalkableTile(room);
-    addBuilder(room, "b-upkeep", "p1", pos.x, pos.y);
-
-    tickUpkeep(room, 1);
-
-    expect(player.wood).toBe(20 - PAWN.BUILDER_UPKEEP_WOOD);
-  });
-
-  it("builder takes UPKEEP_DAMAGE when player has no wood", () => {
-    const room = createRoomWithMap(42);
-    const { player } = joinPlayer(room, "p1");
-
-    player.wood = 0;
-    const pos = findWalkableTile(room);
-    const builder = addBuilder(room, "b-broke", "p1", pos.x, pos.y, {
-      health: PAWN.BUILDER_HEALTH,
-    });
-
-    const healthBefore = builder.health;
-    tickUpkeep(room, 1);
-
-    expect(builder.health).toBeLessThan(healthBefore);
-  });
-
-  it("builder dies from accumulated upkeep damage (removed from creatures)", () => {
-    const room = createRoomWithMap(42);
-    const { player } = joinPlayer(room, "p1");
-
-    player.wood = 0;
-    const pos = findWalkableTile(room);
-    addBuilder(room, "b-starve", "p1", pos.x, pos.y, {
-      health: PAWN.BUILDER_HEALTH,
-    });
-
-    for (let cycle = 1; cycle <= 20; cycle++) {
-      tickUpkeep(room, cycle);
-      if (!room.state.creatures.has("b-starve")) break;
-    }
-
-    expect(room.state.creatures.has("b-starve")).toBe(false);
   });
 });
 

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -16,7 +16,7 @@ import {
   CREATURE_AI, CREATURE_RESPAWN, TERRITORY,
   STRUCTURE_INCOME, SHAPE,
   PROGRESSION, getLevelForXP,
-  PAWN, PAWN_TYPES, DAY_NIGHT, FOG_OF_WAR,
+  PAWN_TYPES, DAY_NIGHT, FOG_OF_WAR,
   ENEMY_SPAWNING, ENEMY_BASE_TYPES,
   DayPhase,
   isEnemyBase,
@@ -55,7 +55,6 @@ export class GameRoom extends Room {
       this.tickCreatureAI();
       this.tickCreatureRespawn();
       this.tickStructureIncome();
-      this.tickPawnUpkeep();
       this.tickEnemyBaseSpawning();
       this.tickCombat();
       this.tickGraveDecay();
@@ -203,41 +202,6 @@ export class GameRoom extends Room {
     return candidates[Math.floor(Math.random() * candidates.length)];
   }
 
-  private tickPawnUpkeep() {
-    if (this.state.tick % PAWN.UPKEEP_INTERVAL_TICKS !== 0) return;
-
-    const toRemove: string[] = [];
-
-    this.state.creatures.forEach((creature) => {
-      if (!creature.pawnType || creature.pawnType === "") return;
-      const pawnDef = PAWN_TYPES[creature.pawnType];
-      if (!pawnDef) return;
-
-      const owner = this.state.players.get(creature.ownerID);
-      if (!owner) {
-        toRemove.push(creature.id);
-        return;
-      }
-
-      if (owner.wood >= pawnDef.upkeep.wood) {
-        owner.wood -= pawnDef.upkeep.wood;
-      } else {
-        creature.health -= PAWN.UPKEEP_DAMAGE;
-        if (creature.health <= 0) {
-          toRemove.push(creature.id);
-          this.broadcast("game_log", { message: `${pawnDef.name} starved (no wood for upkeep)`, type: "death" });
-        } else {
-          this.broadcast("game_log", { message: `${pawnDef.name} taking damage — need wood!`, type: "upkeep" });
-        }
-      }
-    });
-
-    for (const id of toRemove) {
-      this.state.creatures.delete(id);
-    }
-  }
-
-  /** Count Water/Rock tiles in the NxN starting zone around (cx, cy). */
   private countNonWalkableInZone(cx: number, cy: number): number {
     const half = Math.floor(TERRITORY.STARTING_SIZE / 2);
     let count = 0;
@@ -424,6 +388,18 @@ export class GameRoom extends Room {
       const tile = this.state.getTile(x, y);
       if (!tile || !this.state.isWalkable(x, y)) continue;
       if (tile.ownerID !== "") continue;
+
+      // Territorial radius check: reject if ANY tile within Manhattan distance 5 is player-owned
+      const territoryRadius = 5;
+      let nearTerritory = false;
+      for (let ry = -territoryRadius; ry <= territoryRadius && !nearTerritory; ry++) {
+        for (let rx = -territoryRadius; rx <= territoryRadius && !nearTerritory; rx++) {
+          if (Math.abs(rx) + Math.abs(ry) > territoryRadius) continue;
+          const nearby = this.state.getTile(x + rx, y + ry);
+          if (nearby && nearby.ownerID !== "") nearTerritory = true;
+        }
+      }
+      if (nearTerritory) continue;
 
       // Min distance from HQs
       const tooCloseToHQ = hqs.some(

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -390,7 +390,7 @@ export class GameRoom extends Room {
       if (tile.ownerID !== "") continue;
 
       // Territorial radius check: reject if ANY tile within Manhattan distance 5 is player-owned
-      const territoryRadius = 5;
+      const territoryRadius = ENEMY_SPAWNING.MIN_DISTANCE_FROM_TERRITORY;
       let nearTerritory = false;
       for (let ry = -territoryRadius; ry <= territoryRadius && !nearTerritory; ry++) {
         for (let rx = -territoryRadius; rx <= territoryRadius && !nearTerritory; rx++) {

--- a/server/src/rooms/builderAI.ts
+++ b/server/src/rooms/builderAI.ts
@@ -118,9 +118,29 @@ function isValidBuildTile(tile: { type: number; shapeHP: number }): boolean {
 }
 
 /**
+ * Check if a tile is an interior gap: unowned but surrounded on 3+ cardinal
+ * sides by tiles owned by the same player.
+ */
+function isInteriorGap(
+  state: GameState,
+  ownerID: string,
+  x: number,
+  y: number,
+): boolean {
+  let ownedNeighbors = 0;
+  for (const [nx, ny] of [[x-1,y],[x+1,y],[x,y-1],[x,y+1]]) {
+    const neighbor = state.getTile(nx, ny);
+    if (neighbor && neighbor.ownerID === ownerID) ownedNeighbors++;
+  }
+  return ownedNeighbors >= 3;
+}
+
+/**
  * Find the best unclaimed walkable tile adjacent to the builder's owner's territory.
  * Scans within BUILD_SITE_SCAN_RADIUS.
- * Prefers closest tiles, with a tiebreaker favoring outward expansion (further from HQ).
+ * Prioritizes interior gaps (tiles surrounded on 3+ sides by owned territory)
+ * before expanding outward. Within each priority tier, prefers closest tiles
+ * with a tiebreaker favoring outward expansion (further from HQ).
  */
 function findBuildSite(
   creature: CreatureState,
@@ -131,6 +151,7 @@ function findBuildSite(
   let best: { x: number; y: number } | null = null;
   let bestDist = Infinity;
   let bestHqDist = -1;
+  let bestIsGap = false;
 
   for (let dy = -radius; dy <= radius; dy++) {
     for (let dx = -radius; dx <= radius; dx++) {
@@ -145,14 +166,21 @@ function findBuildSite(
       const dist = Math.abs(dx) + Math.abs(dy);
       if (dist === 0) continue;
 
-      // Among equal-distance candidates, prefer tiles further from HQ (outward expansion)
+      const gap = isInteriorGap(state, creature.ownerID, tx, ty);
       const hqDist = player
         ? Math.abs(tx - player.hqX) + Math.abs(ty - player.hqY)
         : 0;
 
-      if (dist < bestDist || (dist === bestDist && hqDist > bestHqDist)) {
+      // Interior gaps always beat non-gaps; within same tier, prefer closer,
+      // then further from HQ (outward expansion bias as secondary tiebreaker)
+      if (
+        (gap && !bestIsGap) ||
+        (gap === bestIsGap && dist < bestDist) ||
+        (gap === bestIsGap && dist === bestDist && hqDist > bestHqDist)
+      ) {
         bestDist = dist;
         bestHqDist = hqDist;
+        bestIsGap = gap;
         best = { x: tx, y: ty };
       }
     }

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -118,7 +118,6 @@ export interface PawnTypeDef {
   readonly creatureType: string;
   readonly health: number;
   readonly cost: { wood: number; stone: number };
-  readonly upkeep: { wood: number };
   readonly maxCount: number;
   readonly damage: number;
   readonly detectionRadius: number;
@@ -205,7 +204,6 @@ export const PAWN_TYPES: Record<string, PawnTypeDef> = {
     creatureType: "pawn_builder",
     health: 50,
     cost: { wood: 10, stone: 5 },
-    upkeep: { wood: 1 },
     maxCount: 5,
     damage: 0,
     detectionRadius: 0,
@@ -221,7 +219,6 @@ export const PAWN_TYPES: Record<string, PawnTypeDef> = {
     creatureType: "pawn_defender",
     health: 80,
     cost: { wood: 15, stone: 10 },
-    upkeep: { wood: 2 },
     maxCount: 3,
     damage: 20,
     detectionRadius: 5,
@@ -237,7 +234,6 @@ export const PAWN_TYPES: Record<string, PawnTypeDef> = {
     creatureType: "pawn_attacker",
     health: 60,
     cost: { wood: 20, stone: 15 },
-    upkeep: { wood: 3 },
     maxCount: 2,
     damage: 25,
     detectionRadius: 6,
@@ -323,12 +319,6 @@ export const PAWN = {
   BUILDER_HEALTH: 50,
   /** Ticks to complete a build (16 ticks = 4 seconds at 4 ticks/sec). */
   BUILD_TIME_TICKS: 16,
-  /** Wood upkeep cost per cycle. */
-  BUILDER_UPKEEP_WOOD: 1,
-  /** Ticks between upkeep deductions (60 ticks = 15 seconds at 4 ticks/sec). */
-  UPKEEP_INTERVAL_TICKS: 60,
-  /** Damage dealt when upkeep can't be paid. */
-  UPKEEP_DAMAGE: 10,
   /** Maximum builders per player. */
   MAX_PER_PLAYER: 5,
   /** Radius to scan for build sites. */

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -265,6 +265,8 @@ export const ENEMY_SPAWNING = {
   MIN_DISTANCE_FROM_HQ: 15,
   MIN_DISTANCE_BETWEEN_BASES: 10,
   FIRST_BASE_DELAY_TICKS: 240,
+  /** Manhattan radius around player territory that rejects enemy base spawns. */
+  MIN_DISTANCE_FROM_TERRITORY: 5,
   /** Maximum ticks an attacker stays on sortie before returning. */
   ATTACKER_SORTIE_TICKS: 200,
 } as const;


### PR DESCRIPTION
## Changes

### Gameplay Fixes (Pemulis)
- **Enemy camp spawn buffer:** Enemy bases can no longer spawn within 5 tiles of player territory
- **Builder interior fill:** Builders now prioritize filling interior gaps (3+ owned neighbors) before expanding outward
- **Pawn wood upkeep removed:** `tickPawnUpkeep()` disabled — pawns no longer consume wood; "need wood" messages eliminated

### PR Review Feedback (Steeply + Marathe)
- **Builder tests:** 3 new tests — traversal through own structures, FSM reset when stuck, HQ-distance tiebreaker
- **Server config:** `clientUrl` now configurable via `CLIENT_URL` env var (default `http://localhost:3000`)
- **Decision log date fix:** Replaced unexpanded `$(date)` placeholder with actual timestamp

### Infrastructure
- **Server QoL:** Client URL logged on server startup
- **Scoreboard fix (#38):** Removed territory column from scoreboard (Gately)
- **Builder pathing fix (#39):** Builders traverse own structures + outward-expansion bias (Pemulis)

Closes #38, Closes #39