### PR TITLE
feat: wire client-side session persistence with auto-guest auth

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -1279,3 +1279,14 @@ See `.squad/decisions.md` Initiative Triage & Execution Plan (2026-03-09) for fu
 - **Key file:** `client/src/renderer/CreatureRenderer.ts` — `tick()` method and `STACK_OFFSETS` constant.
 - **Tests:** `client/src/__tests__/creature-stacking.test.ts` — 4 regression tests with PixiJS mocks.
 - **Pattern:** PixiJS mocking pattern reused from `camera-zoom.test.ts` — mock Container/Graphics/Text classes, stub `@primal-grid/shared` and `GridRenderer.js`.
+
+### Client-Side Session Persistence — #77 (2026-03-XX)
+
+## Learnings
+- **Auth URL derivation:** Server runs Express (HTTP auth) and Colyseus (WS game) on the same host:port. Derived HTTP URL from WS URL with regex: `ws(s?)://` → `http$1://`. Handles both ws/wss correctly.
+- **Auth response shape:** `POST /auth/guest` returns `{ user: { id, username, isGuest }, token: { accessToken, expiresIn } }`. Token is a JWT with 24h expiry.
+- **SERVER_PORT is 2567** (not 3001 as sometimes referenced). Defined in `shared/src/constants.ts`.
+- **GameRoom.onJoin() is auth-optional:** Server silently allows join even with invalid/missing token — it just skips state restoration. No error thrown. This means the retry-on-expired pattern is defensive, not strictly required for basic play.
+- **Token stored under `primal-grid-token`** in localStorage. Wrapped in try/catch for private browsing compatibility.
+- **Key file:** `client/src/network.ts` — auth helpers (`ensureToken`, `createGuestSession`, `loadToken`, `saveToken`, `clearToken`) + `connect()` with token flow and retry logic.
+- **PR:** #78 targeting dev.

--- a/.squad/agents/hal/history.md
+++ b/.squad/agents/hal/history.md
@@ -675,3 +675,7 @@ Analyzed dependencies and created formal execution plan for four GitHub issues:
 - Pemulis begins #42 immediately
 - Gately picks up #19 after PR #68 merge (scheduled ~2026-03-10)
 - Steeply prepares #42 auth test suite
+
+- **2026-03 PR #78 Review (Silent Guest Auth):** Reviewed Gately's client-side session persistence PR. Found two blocking issues: (1) CORS — `fetch()` to `http://localhost:2567/auth/guest` from Vite on `http://localhost:3000` will be blocked; Express server has no CORS middleware. (2) No graceful degradation — if `createGuestSession()` throws, `connect()` fails entirely even though `GameRoom.onJoin()` is auth-optional. Also flagged duplicated room-setup code in the retry path. Lint clean. Auth URL derivation (`ws(s)://` → `http(s)://`) is correct. Requested changes via PR comment (couldn't use request-changes since bot authored the PR).
+
+- **2026-03 PR #78 Re-review (Session Persistence — Approved):** Pemulis addressed all three requested changes: (1) CORS middleware added via `app.use(cors())` on Express. (2) `ensureToken()` now catches failures and returns `undefined`; `connect()` falls back to anonymous join with three retry layers. (3) `setupRoom()` helper extracted to DRY lifecycle wiring across all join paths. Lint clean, no `any` types. Approved via comment (can't use `--approve` on bot-authored PRs). Ready to merge.

--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1748,3 +1748,10 @@ See `.squad/decisions.md` for full triage document, dependency graph, risk mitig
 - **Design trade-off**: Resources/territory NOT restored on rejoin — territory is spatial and map-dependent. Only score/level/XP/displayName persist.
 - **Dependencies added**: jsonwebtoken, better-sqlite3, bcryptjs (+ @types/).
 - **Test impact**: 515/515 tests pass, zero regressions. Key insight: `onLeave` must stay synchronous because tests call it without `await`.
+
+### PR #78 Review Fixes — CORS, Auth Degradation, DRY (2026-03-12)
+
+- **CORS middleware**: Added `cors` package to Express server (`server/src/index.ts`). Required because `fetch()` auth calls from Vite dev server (port 3000) to Colyseus (port 2567) are cross-origin. WebSocket connections bypass CORS but HTTP fetch does not.
+- **Graceful auth degradation**: `ensureToken()` now returns `string | undefined` — catches auth failures silently. `connect()` joins without a token when auth is unavailable. If token-bearing join fails, falls back to anonymous join. Game is always playable with zero auth infrastructure.
+- **DRY room setup**: Extracted `setupRoom()` helper in `client/src/network.ts` — eliminates duplicated `onLeave`/`onError`/`__ROOM__` assignment between initial join and retry paths.
+- **Key pattern**: Auth is strictly optional on both sides. Server's `GameRoom.onJoin()` skips state restoration when no token provided. Client's `connect()` gracefully degrades to anonymous join on any auth failure.

--- a/.squad/decisions/inbox/gately-session-persistence.md
+++ b/.squad/decisions/inbox/gately-session-persistence.md
@@ -1,0 +1,20 @@
+# Decision: Client Auth Token Storage & Silent Guest Flow
+
+**Author:** Gately  
+**Date:** 2026-03-XX  
+**Issue:** #77  
+**PR:** #78  
+
+## Context
+The server-side JWT auth system (PR #70) was fully built but the client never called any auth endpoints. Players couldn't persist progress across sessions.
+
+## Decision
+- **Token key:** `primal-grid-token` in localStorage
+- **Auth URL:** Derived from WS URL by replacing `ws://` → `http://` (same host:port)
+- **Flow:** Auto-guest on first visit, reuse token on return, silent refresh on expiry
+- **No UI:** Guest auth is completely invisible to the user
+
+## Impact
+- Future login/register UI should use the same `saveToken()` / `clearToken()` helpers in `client/src/network.ts`
+- Account upgrade flow (`POST /auth/upgrade`) should replace the stored token with the new one
+- All auth-related client logic lives in `client/src/network.ts` — no separate auth module yet

--- a/.squad/decisions/inbox/pemulis-cors-auth-degradation.md
+++ b/.squad/decisions/inbox/pemulis-cors-auth-degradation.md
@@ -1,0 +1,11 @@
+## CORS + Auth Graceful Degradation (Pemulis, 2026-03-12)
+
+**Context:** PR #78 review feedback from Hal.
+
+**Decisions:**
+
+1. **CORS via `cors` npm package** on Express server — permissive (`cors()` with defaults). Needed for dev mode where Vite (port 3000) makes `fetch()` calls to Colyseus (port 2567). In production, same-origin serves both, so CORS headers are harmless but unused.
+
+2. **Auth is always optional on the client.** If `ensureToken()` fails for any reason (network, CORS, server down), the client joins the room without a token. If a token-bearing join fails, the client retries without auth. The game must never crash due to auth infrastructure being unavailable.
+
+**Impact:** All agents touching `connect()` or adding auth endpoints should respect this pattern — auth failures are warnings, never errors.

--- a/client/src/network.ts
+++ b/client/src/network.ts
@@ -81,18 +81,41 @@ async function createGuestSession(): Promise<string> {
 
 /**
  * Ensure we have a valid token. On first visit, silently creates a guest
- * session. On return visit, reuses the stored token. If the server rejects
- * the token during room join, the caller will retry with a fresh guest token.
+ * session. On return visit, reuses the stored token. Returns undefined if
+ * auth is unavailable — the game remains playable without persistence.
  */
-async function ensureToken(): Promise<string> {
+async function ensureToken(): Promise<string | undefined> {
   const existing = loadToken();
   if (existing) {
     return existing;
   }
-  console.log('[auth] No stored token — creating guest session');
-  const token = await createGuestSession();
-  saveToken(token);
-  return token;
+  try {
+    console.log('[auth] No stored token — creating guest session');
+    const token = await createGuestSession();
+    saveToken(token);
+    return token;
+  } catch (err) {
+    console.warn('[auth] Guest auth unavailable — continuing without session persistence', err);
+    return undefined;
+  }
+}
+
+/** Attach lifecycle handlers and dev-mode bindings to a newly joined room. */
+function setupRoom(joined: Room): void {
+  if (import.meta.env.DEV || isDevMode()) {
+    (window as unknown as Record<string, unknown>).__ROOM__ = joined;
+  }
+
+  joined.onLeave(() => {
+    console.log('[network] Left room');
+    statusCallback?.('disconnected');
+    room = null;
+  });
+
+  joined.onError((code, message) => {
+    console.error('[network] Room error:', code, message);
+    statusCallback?.('error');
+  });
 }
 
 export async function connect(): Promise<Room> {
@@ -102,7 +125,10 @@ export async function connect(): Promise<Room> {
 
   const token = await ensureToken();
 
-  const joinOptions: Record<string, unknown> = { token };
+  const joinOptions: Record<string, unknown> = {};
+  if (token) {
+    joinOptions.token = token;
+  }
   if (isDevMode()) {
     joinOptions.devMode = true;
     console.log('[network] Dev mode enabled — fog of war disabled');
@@ -112,61 +138,56 @@ export async function connect(): Promise<Room> {
     room = await client.joinOrCreate('game', joinOptions);
     console.log('[network] Joined room:', room.roomId);
     statusCallback?.('connected');
-
-    // Expose room reference for Playwright E2E testing (dev mode only)
-    if (import.meta.env.DEV || isDevMode()) {
-      (window as unknown as Record<string, unknown>).__ROOM__ = room;
-    }
-
-    room.onLeave(() => {
-      console.log('[network] Left room');
-      statusCallback?.('disconnected');
-      room = null;
-    });
-
-    room.onError((code, message) => {
-      console.error('[network] Room error:', code, message);
-      statusCallback?.('error');
-    });
-
+    setupRoom(room);
     return room;
   } catch (err) {
     // If join failed, the token may be expired — clear and retry once
     const isRetryable =
+      token &&
       err instanceof Error &&
       (err.message.includes('token') || err.message.includes('401'));
 
     if (isRetryable && loadToken()) {
       console.log('[auth] Token rejected — refreshing guest session');
       clearToken();
-      const freshToken = await createGuestSession();
-      saveToken(freshToken);
-      joinOptions.token = freshToken;
+
+      try {
+        const freshToken = await createGuestSession();
+        saveToken(freshToken);
+        joinOptions.token = freshToken;
+      } catch {
+        // Auth is down — fall back to anonymous join
+        console.warn('[auth] Token refresh failed — joining without auth');
+        delete joinOptions.token;
+      }
 
       try {
         room = await client.joinOrCreate('game', joinOptions);
         console.log('[network] Joined room (retry):', room.roomId);
         statusCallback?.('connected');
-
-        if (import.meta.env.DEV || isDevMode()) {
-          (window as unknown as Record<string, unknown>).__ROOM__ = room;
-        }
-
-        room.onLeave(() => {
-          console.log('[network] Left room');
-          statusCallback?.('disconnected');
-          room = null;
-        });
-        room.onError((code, message) => {
-          console.error('[network] Room error:', code, message);
-          statusCallback?.('error');
-        });
-
+        setupRoom(room);
         return room;
       } catch (retryErr) {
         console.error('[network] Retry connection failed:', retryErr);
         statusCallback?.('disconnected');
         throw retryErr;
+      }
+    }
+
+    // If auth failed but we had a token, try once more without auth
+    if (token) {
+      console.warn('[network] Join failed with token — retrying without auth');
+      delete joinOptions.token;
+      try {
+        room = await client.joinOrCreate('game', joinOptions);
+        console.log('[network] Joined room (anonymous fallback):', room.roomId);
+        statusCallback?.('connected');
+        setupRoom(room);
+        return room;
+      } catch (fallbackErr) {
+        console.error('[network] Anonymous fallback failed:', fallbackErr);
+        statusCallback?.('disconnected');
+        throw fallbackErr;
       }
     }
 

--- a/client/src/network.ts
+++ b/client/src/network.ts
@@ -4,6 +4,13 @@ import { SERVER_PORT } from '@primal-grid/shared';
 export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 type StatusCallback = (status: ConnectionStatus) => void;
 
+const TOKEN_KEY = 'primal-grid-token';
+
+interface AuthResponse {
+  user: { id: string; username: string; isGuest: boolean };
+  token: { accessToken: string; expiresIn: number };
+}
+
 let room: Room | null = null;
 let statusCallback: StatusCallback | null = null;
 
@@ -22,9 +29,70 @@ function getServerUrl(): string {
   return `ws://localhost:${SERVER_PORT}`;
 }
 
+/** Derive an HTTP URL from the WebSocket server URL for auth API calls. */
+function getHttpUrl(): string {
+  const wsUrl = getServerUrl();
+  return wsUrl.replace(/^ws(s?):\/\//, 'http$1://');
+}
+
 export function isDevMode(): boolean {
   const params = new URLSearchParams(window.location.search);
   return params.get('dev') === '1' || params.get('devmode') === '1';
+}
+
+// ---------------------------------------------------------------------------
+// Auth helpers — silent guest flow, token persistence
+// ---------------------------------------------------------------------------
+
+function loadToken(): string | null {
+  try {
+    return localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function saveToken(token: string): void {
+  try {
+    localStorage.setItem(TOKEN_KEY, token);
+  } catch {
+    // Storage full or blocked — continue without persistence
+  }
+}
+
+function clearToken(): void {
+  try {
+    localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    // Ignore
+  }
+}
+
+/** Create a guest session and return the JWT access token. */
+async function createGuestSession(): Promise<string> {
+  const url = `${getHttpUrl()}/auth/guest`;
+  const res = await fetch(url, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`Guest auth failed: ${res.status}`);
+  }
+  const data: AuthResponse = await res.json() as AuthResponse;
+  return data.token.accessToken;
+}
+
+/**
+ * Ensure we have a valid token. On first visit, silently creates a guest
+ * session. On return visit, reuses the stored token. If the server rejects
+ * the token during room join, the caller will retry with a fresh guest token.
+ */
+async function ensureToken(): Promise<string> {
+  const existing = loadToken();
+  if (existing) {
+    return existing;
+  }
+  console.log('[auth] No stored token — creating guest session');
+  const token = await createGuestSession();
+  saveToken(token);
+  return token;
 }
 
 export async function connect(): Promise<Room> {
@@ -32,7 +100,9 @@ export async function connect(): Promise<Room> {
   statusCallback?.('connecting');
   console.log('[network] Connecting to server…');
 
-  const joinOptions: Record<string, unknown> = {};
+  const token = await ensureToken();
+
+  const joinOptions: Record<string, unknown> = { token };
   if (isDevMode()) {
     joinOptions.devMode = true;
     console.log('[network] Dev mode enabled — fog of war disabled');
@@ -61,6 +131,45 @@ export async function connect(): Promise<Room> {
 
     return room;
   } catch (err) {
+    // If join failed, the token may be expired — clear and retry once
+    const isRetryable =
+      err instanceof Error &&
+      (err.message.includes('token') || err.message.includes('401'));
+
+    if (isRetryable && loadToken()) {
+      console.log('[auth] Token rejected — refreshing guest session');
+      clearToken();
+      const freshToken = await createGuestSession();
+      saveToken(freshToken);
+      joinOptions.token = freshToken;
+
+      try {
+        room = await client.joinOrCreate('game', joinOptions);
+        console.log('[network] Joined room (retry):', room.roomId);
+        statusCallback?.('connected');
+
+        if (import.meta.env.DEV || isDevMode()) {
+          (window as unknown as Record<string, unknown>).__ROOM__ = room;
+        }
+
+        room.onLeave(() => {
+          console.log('[network] Left room');
+          statusCallback?.('disconnected');
+          room = null;
+        });
+        room.onError((code, message) => {
+          console.error('[network] Room error:', code, message);
+          statusCallback?.('error');
+        });
+
+        return room;
+      } catch (retryErr) {
+        console.error('[network] Retry connection failed:', retryErr);
+        statusCallback?.('disconnected');
+        throw retryErr;
+      }
+    }
+
     console.error('[network] Connection failed:', err);
     statusCallback?.('disconnected');
     throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2671,6 +2671,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3849,6 +3859,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -5918,6 +5945,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -8895,12 +8931,14 @@
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.6.2",
         "colyseus": "^0.17.8",
+        "cors": "^2.8.6",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
         "tsx": "^4.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -13,12 +13,14 @@
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.6.2",
     "colyseus": "^0.17.8",
+    "cors": "^2.8.6",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "tsx": "^4.0.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,7 @@ import { createServer } from "http";
 import path from "path";
 import { fileURLToPath } from "url";
 import express from "express";
+import cors from "cors";
 import { Server } from "colyseus";
 import { WebSocketTransport } from "@colyseus/ws-transport";
 import { Encoder } from "@colyseus/schema";
@@ -26,6 +27,7 @@ const playerStateRepo = new SqlitePlayerStateRepository(DB_PATH);
 const authProvider = new LocalAuthProvider(userRepo, JWT_SECRET);
 
 const app = express();
+app.use(cors());
 app.use(express.json());
 
 // Auth API routes


### PR DESCRIPTION
## Summary

Wires up the client-side auth plumbing so the server's JWT auth system (from PR #70) actually gets used. Players now get persistent sessions transparently — no UI changes needed.

### What this does

1. **Auto-guest on first visit**: When no token exists in localStorage, silently calls `POST /auth/guest` to get a JWT token
2. **Token storage**: Saves the JWT under `primal-grid-token` in localStorage
3. **Token in room join**: Passes `{ token }` in join options so `GameRoom.onJoin()` can validate and restore saved state
4. **Return visit flow**: Loads stored token → passes to room join → server validates → loads saved state → progress restored
5. **Silent expiry handling**: If room join fails with a token error, clears the old token, creates a fresh guest session, and retries — user never sees an error

### Key design decisions

- **HTTP URL derived from WS URL**: `getHttpUrl()` converts `ws://` → `http://` (and `wss://` → `https://`) so auth fetch calls hit the same Express server
- **No UI changes**: This is pure plumbing — the guest flow is completely invisible to the user
- **Retry-once pattern**: Only retries on token-related errors to avoid infinite loops
- **localStorage wrapped in try/catch**: Handles private browsing / storage-blocked scenarios gracefully

### Files changed

- `client/src/network.ts` — auth helpers + connect() wired with token flow

Closes #77

Working as Gately (Game Dev)