### PR TITLE
fix: session persistence — score inflation and resource overwrite

### DIFF
--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1786,3 +1786,19 @@ See `.squad/decisions.md` for full triage document, dependency graph, risk mitig
 - **Graceful auth degradation**: `ensureToken()` now returns `string | undefined` — catches auth failures silently. `connect()` joins without a token when auth is unavailable. If token-bearing join fails, falls back to anonymous join. Game is always playable with zero auth infrastructure.
 - **DRY room setup**: Extracted `setupRoom()` helper in `client/src/network.ts` — eliminates duplicated `onLeave`/`onError`/`__ROOM__` assignment between initial join and retry paths.
 - **Key pattern**: Auth is strictly optional on both sides. Server's `GameRoom.onJoin()` skips state restoration when no token provided. Client's `connect()` gracefully degrades to anonymous join on any auth failure.
+
+### Session Persistence Bug Fix (2026-03-13)
+
+**Bug:** Browser refresh always showed the name prompt, even when the server successfully restored the player's identity (displayName, score, XP, level) from the persistence layer via JWT token.
+
+**Root cause:** `client/src/main.ts` called `promptForName()` unconditionally after every `connect()`. The server-side auth/restore flow was correct — the bug was purely client-side.
+
+**Fix (2 files):**
+- `client/src/main.ts`: After `connect()`, check `room.state.players.get(room.sessionId).displayName`. Only show the name prompt if the server didn't restore one. In Colyseus 0.17+, initial state is synced before `joinOrCreate` resolves.
+- `server/src/rooms/GameRoom.ts`: Differentiated welcome messages — returning players see "Welcome back, {name}!" and a "{name} has returned" broadcast goes to other players.
+
+## Learnings
+
+- **Colyseus 0.17 state sync timing**: `joinOrCreate` resolves AFTER the initial state snapshot is applied. `room.state.players.get(room.sessionId)` is available immediately after the promise resolves — no need to wait for `onStateChange`.
+- **Auth flow data path**: Token in localStorage → `ensureToken()` → `joinOptions.token` → server `onJoin` validates via `authProvider.validateToken()` → `sessionUserMap` maps sessionId→userId → `playerStateRepo.load(userId)` → `deserializePlayerState()` restores displayName/score/level/xp.
+- **Key files for session persistence**: `client/src/network.ts` (token storage), `client/src/main.ts` (name prompt gating), `server/src/rooms/GameRoom.ts` (onJoin restore, onLeave save, auto-save), `server/src/persistence/playerStateSerde.ts` (serde).

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -100,9 +100,13 @@ async function connectToServer(app: Application, grid: GridRenderer, camera: Cam
   try {
     const room = await connect();
 
-    // Prompt for display name and send to server
-    const displayName = await promptForName();
-    room.send(SET_NAME, { name: displayName });
+    // If the server restored a displayName from a previous session, skip the prompt.
+    // In Colyseus 0.17+, initial state is synced before joinOrCreate resolves.
+    const localPlayer = room.state.players?.get(room.sessionId);
+    if (!localPlayer?.displayName) {
+      const displayName = await promptForName();
+      room.send(SET_NAME, { name: displayName });
+    }
 
     // Bind renderers to server state
     grid.setLocalPlayerId(room.sessionId);

--- a/server/src/__tests__/auth-room-integration.test.ts
+++ b/server/src/__tests__/auth-room-integration.test.ts
@@ -161,10 +161,14 @@ describe("GameRoom Auth Integration", () => {
 
       const player = room.state.players.get("session-restore")!;
       expect(player.displayName).toBe("SavedRex");
-      // Score includes restored value + HQ territory tiles claimed on join
-      expect(player.score).toBeGreaterThanOrEqual(500);
+      // Score reflects actual territory (spawnHQ tiles), NOT the saved value.
+      // Saved score is intentionally not restored — it's a spatial metric.
+      expect(player.score).toBeGreaterThan(0);
       expect(player.level).toBe(5);
       expect(player.xp).toBe(250);
+      // Resources ARE restored after spawnHQ
+      expect(player.wood).toBe(99);
+      expect(player.stone).toBe(88);
     });
 
     it("creates fresh player when no saved state exists", async () => {

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -10,8 +10,8 @@ import type { EnemyBaseTracker } from "./enemyBaseAI.js";
 import type { AttackerTracker } from "./attackerAI.js";
 import type { AuthProvider, AuthUser } from "../auth/AuthProvider.js";
 import type { PlayerStateRepository } from "../persistence/PlayerStateRepository.js";
-import { serializePlayerState } from "../persistence/playerStateSerde.js";
-import { deserializePlayerState } from "../persistence/playerStateSerde.js";
+import { serializePlayerState, deserializePlayerState } from "../persistence/playerStateSerde.js";
+import type { SerializedPlayerState } from "../persistence/playerStateSerde.js";
 import {
   TICK_RATE, DEFAULT_MAP_SIZE, DEFAULT_MAP_SEED,
   SPAWN_PAWN, SET_NAME, CHAT, CHAT_MAX_LENGTH,
@@ -107,17 +107,19 @@ export class GameRoom extends Room {
     player.id = client.sessionId;
     player.color = PLAYER_COLORS[this.state.players.size % PLAYER_COLORS.length];
 
-    // Restore saved state if authenticated and persistence is configured
+    // Restore saved state if authenticated and persistence is configured.
+    // Only displayName is set before spawnHQ (needed for client name-prompt skip).
+    // Progression stats (level, xp) and resources (wood, stone) are restored AFTER
+    // spawnHQ, which resets score/resources to starting values.
+    // Score is NOT restored — it reflects actual current territory, not historical totals.
     let restored = false;
+    let savedState: SerializedPlayerState | null = null;
     if (authUser && this.playerStateRepo) {
       const saved = await this.playerStateRepo.load(authUser.id);
       if (saved) {
-        const parsed = deserializePlayerState(saved.gameState);
-        if (parsed) {
-          player.displayName = parsed.displayName;
-          player.score = parsed.score;
-          player.level = parsed.level;
-          player.xp = parsed.xp;
+        savedState = deserializePlayerState(saved.gameState);
+        if (savedState) {
+          player.displayName = savedState.displayName;
           restored = true;
           console.log(`[GameRoom] Restored state for user ${authUser.username}`);
         }
@@ -126,15 +128,18 @@ export class GameRoom extends Room {
 
     this.state.players.set(client.sessionId, player);
 
-    // Spawn HQ and claim starting territory
+    // Spawn HQ and claim starting territory (sets score = tile count, resets resources)
     const hqPos = this.findHQSpawnLocation();
     spawnHQ(this.state, player, hqPos.x, hqPos.y);
 
-    // Restore resources after HQ spawn (which sets starting resources)
-    // Only override if we have a saved state with more resources
-    if (restored) {
-      // Player keeps their saved score/xp/level but gets fresh resources and territory
-      // (territory is spatial — can't meaningfully restore across different map seeds)
+    // Restore earned progression and resources after HQ spawn.
+    // Territory is spatial and can't transfer across map seeds, so score stays
+    // at the actual tile count set by spawnHQ.
+    if (restored && savedState) {
+      player.wood = savedState.wood;
+      player.stone = savedState.stone;
+      player.level = savedState.level;
+      player.xp = savedState.xp;
     }
 
     const devMode = options?.devMode === true;

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -153,7 +153,13 @@ export class GameRoom extends Room {
 
     const userLabel = authUser ? ` (user: ${authUser.username})` : "";
     console.log(`[GameRoom] Client joined: ${client.sessionId}${userLabel}, HQ at (${hqPos.x}, ${hqPos.y})${devMode ? ' [DEV MODE]' : ''}`);
-    client.send("game_log", { message: "Welcome to Primal Grid!", type: "info" });
+
+    if (restored && player.displayName) {
+      client.send("game_log", { message: `Welcome back, ${player.displayName}!`, type: "info" });
+      this.broadcast("game_log", { message: `${player.displayName} has returned`, type: "info" }, { except: client });
+    } else {
+      client.send("game_log", { message: "Welcome to Primal Grid!", type: "info" });
+    }
   }
 
   override onLeave(client: Client, code: number) {


### PR DESCRIPTION
## Problem
Refreshing the browser showed mismatched state:
- **Score inflated**: Saved score was restored, then `spawnHQ()` added +25 more tiles on top. Player sees 75 tiles but only has 25 on the map.
- **Resources lost**: `spawnHQ()` unconditionally reset wood/stone to starting values, overwriting restored amounts. The `if (restored)` block was empty.

## Fix
Reorder the restore logic so:
1. **displayName** is set before state sync (so client skips name prompt)
2. **spawnHQ()** runs and sets score = actual territory count (25 tiles)
3. **After** spawnHQ, restore wood, stone, level, xp from saved state
4. **Score is NOT restored** — it's a spatial metric that should match actual territory

## Test
Updated auth-room-integration test to verify resources ARE restored and score reflects actual territory (not saved + new).

Closes #82 (if applicable)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>