### PR TITLE
fix: relax flaky mapgen timing thresholds (#104)

### DIFF
--- a/.squad/agents/steeply/history.md
+++ b/.squad/agents/steeply/history.md
@@ -1965,3 +1965,11 @@ Large-map rendering with PixiJS requires explicit culling—the scene graph does
   ```
 - **3 new tests added** to `reconnection.test.ts` under "Browser refresh guard (pageUnloading)": (1) token preserved during refresh, (2) cancelled navigation resets flag via pageshow, (3) normal disconnect after pageshow still cleans up. Total: 21 tests in file, 696 across full suite.
 - **Follow-up action items:** (1) @copilot's PR #103 still pending Hal review (flagged 🟡 needs-review), (2) New implementer needed to add `pageUnloading` reset fix (Pemulis/Gately locked out per protocol), (3) Steeply to write test coverage spec for `pageshow` event reset.
+
+### Flaky Mapgen Performance Tests — Issue #104, PR #106 (2026-03-10)
+
+- **Three perf tests across two files had tight timing thresholds** that flake on slow CI runners: `map-size.test.ts` (500ms map, 1000ms map+creatures) and `water-depth.test.ts` (500ms map).
+- **Fix:** Increased hard ceilings to 5x (2500ms map, 5000ms map+creatures) and added `console.warn` at the original ideal thresholds for regression visibility without CI breakage.
+- **Key principle:** Performance tests in CI should catch algorithmic regressions (O(n²) → O(n³)), not benchmark absolute speed. Hard ceilings must tolerate 5x variance for different environments.
+- **Files modified:** `server/src/__tests__/map-size.test.ts`, `server/src/__tests__/water-depth.test.ts`
+- **Full suite:** 696 tests, 43 files, all passing.

--- a/.squad/decisions/inbox/steeply-perf-test-thresholds.md
+++ b/.squad/decisions/inbox/steeply-perf-test-thresholds.md
@@ -1,0 +1,21 @@
+# Decision: Performance Test Threshold Policy
+
+**Author:** Steeply (Tester)
+**Date:** 2026-03-10
+**Issue:** #104
+**PR:** #106
+
+## Decision
+
+Performance tests in CI use a **two-tier threshold** pattern:
+
+1. **Ideal threshold** — the expected runtime on a fast machine. Exceeding this emits a `console.warn` so regressions are visible in logs.
+2. **Hard ceiling** — 5x the ideal threshold. Only this value is asserted with `expect()`. Failing this means an actual algorithmic regression, not environment variance.
+
+## Rationale
+
+CI runners vary in speed (shared VMs, load spikes, cold caches). Hard-asserting tight thresholds creates flaky tests that erode trust in the suite. The goal of perf tests in CI is to catch algorithmic regressions (O(n²) → O(n³)), not to benchmark absolute speed. The warn-at-ideal / fail-at-ceiling pattern gives us both visibility and stability.
+
+## Applies To
+
+All timing-based performance assertions in the test suite.

--- a/server/src/__tests__/map-size.test.ts
+++ b/server/src/__tests__/map-size.test.ts
@@ -121,18 +121,35 @@ describe("Map Size (#11)", () => {
   });
 
   describe("generation performance", () => {
-    it("map generation completes in under 500ms", () => {
+    // Hard ceilings are generous (5x ideal) to avoid CI flakes.
+    // console.warn fires at the ideal threshold so regressions stay visible.
+    const MAP_IDEAL_MS = 500;
+    const MAP_HARD_CEILING_MS = 2500;
+    const CREATURES_IDEAL_MS = 1000;
+    const CREATURES_HARD_CEILING_MS = 5000;
+
+    it("map generation completes within performance ceiling", () => {
       const start = performance.now();
       createRoomWithMap(42);
       const elapsed = performance.now() - start;
-      expect(elapsed).toBeLessThan(500);
+      if (elapsed > MAP_IDEAL_MS) {
+        console.warn(
+          `⚠ Map generation took ${elapsed.toFixed(0)}ms (ideal < ${MAP_IDEAL_MS}ms)`,
+        );
+      }
+      expect(elapsed).toBeLessThan(MAP_HARD_CEILING_MS);
     });
 
-    it("map generation with creatures completes in under 1000ms", () => {
+    it("map generation with creatures completes within performance ceiling", () => {
       const start = performance.now();
       createRoomWithCreatures(42);
       const elapsed = performance.now() - start;
-      expect(elapsed).toBeLessThan(1000);
+      if (elapsed > CREATURES_IDEAL_MS) {
+        console.warn(
+          `⚠ Map + creature generation took ${elapsed.toFixed(0)}ms (ideal < ${CREATURES_IDEAL_MS}ms)`,
+        );
+      }
+      expect(elapsed).toBeLessThan(CREATURES_HARD_CEILING_MS);
     });
   });
 });

--- a/server/src/__tests__/water-depth.test.ts
+++ b/server/src/__tests__/water-depth.test.ts
@@ -324,7 +324,10 @@ describe("Water Depth Variants", () => {
 
   // ─── 4. Map generation performance ──────────────────────────────
   describe("Map generation performance", () => {
-    it("128×128 map generates in under 500ms (no perf regression from water depth pass)", () => {
+    const MAP_IDEAL_MS = 500;
+    const MAP_HARD_CEILING_MS = 2500;
+
+    it("128×128 map generates within performance ceiling (no perf regression from water depth pass)", () => {
       const room = Object.create(GameRoom.prototype) as GameRoom;
       room.state = new GameState();
       room.state.mapWidth = DEFAULT_MAP_SIZE;
@@ -335,7 +338,12 @@ describe("Water Depth Variants", () => {
       room.generateMap(42);
       const elapsed = performance.now() - start;
 
-      expect(elapsed).toBeLessThan(500);
+      if (elapsed > MAP_IDEAL_MS) {
+        console.warn(
+          `⚠ Map generation took ${elapsed.toFixed(0)}ms (ideal < ${MAP_IDEAL_MS}ms)`,
+        );
+      }
+      expect(elapsed).toBeLessThan(MAP_HARD_CEILING_MS);
       expect(room.state.tiles.length).toBe(DEFAULT_MAP_SIZE * DEFAULT_MAP_SIZE);
     });
   });


### PR DESCRIPTION
Closes #104

Working as Steeply (Tester)

## Changes
- Relaxed timing thresholds in map-size.test.ts to prevent CI flakes (500ms → 2500ms for map, 1000ms → 5000ms for map+creatures)
- Added console.warn at the original ideal thresholds so perf regressions are still visible in logs
- Fixed same flaky threshold in water-depth.test.ts (500ms → 2500ms)

## Rationale
These tests exist to catch algorithmic regressions (e.g. O(n²) → O(n³)), not to benchmark absolute speed. The generous hard ceilings tolerate slow CI runners, while the warn thresholds keep regressions visible. All 696 tests pass.