### PR TITLE
Add stage:ready-for-uat label automation on dev merge

### DIFF
--- a/.github/workflows/squad-stage-label.yml
+++ b/.github/workflows/squad-stage-label.yml
@@ -1,0 +1,50 @@
+name: Squad Stage Label
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  label-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply stage:ready-for-uat to linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Parse linked issue numbers from PR body
+            const pattern = /(?:closes|fixes|resolves)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+            let match;
+            while ((match = pattern.exec(body)) !== null) {
+              issueNumbers.add(parseInt(match[1], 10));
+            }
+
+            if (issueNumbers.size === 0) {
+              core.info('No linked issues found in PR body — nothing to label');
+              return;
+            }
+
+            core.info(`Found linked issues: ${[...issueNumbers].join(', ')}`);
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: ['stage:ready-for-uat']
+                });
+                core.info(`Applied stage:ready-for-uat to #${issueNumber}`);
+              } catch (err) {
+                core.warning(`Failed to label #${issueNumber}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow (`.github/workflows/squad-stage-label.yml`) that automatically applies the `stage:ready-for-uat` label to linked issues when a PR is merged to `dev`.

Working as Marathe (DevOps / CI-CD).

## What it does

- Triggers on `pull_request` closed events targeting `dev`
- Only runs when the PR was actually merged (not just closed)
- Parses the PR body for `Closes #N`, `Fixes #N`, `Resolves #N` patterns (case-insensitive)
- Applies `stage:ready-for-uat` to each linked issue
- Logs warnings for any issues that can't be labeled (e.g., invalid issue numbers)

## Design choices

- Uses `actions/github-script@v7` — consistent with existing squad workflows
- Minimal permissions: `issues: write` only
- No checkout needed (no filesystem access required)
- Regex uses a `Set` to deduplicate issue numbers

## Also done

- Manually applied `stage:ready-for-uat` to issue #101 (PR #103 was already merged to dev)
- Created issue #107 to track this work

Closes #107