### PR TITLE
feat: add Explorer pawn type (#59)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -77,13 +77,15 @@
         cursor: not-allowed;
       }
       #spawn-defender-btn:not(:disabled):hover,
-      #spawn-attacker-btn:not(:disabled):hover {
+      #spawn-attacker-btn:not(:disabled):hover,
+      #spawn-explorer-btn:not(:disabled):hover {
         background: #3a3a5a;
         border-color: #7ecfff;
         color: #ffffff;
       }
       #spawn-defender-btn:disabled,
-      #spawn-attacker-btn:disabled {
+      #spawn-attacker-btn:disabled,
+      #spawn-explorer-btn:disabled {
         opacity: 0.4;
         cursor: not-allowed;
       }
@@ -621,6 +623,7 @@
           <div style="display:flex;gap:4px;font-size:11px;margin-bottom:6px;">
             <span id="defender-count">🛡 0/3</span>
             <span id="attacker-count">⚔ 0/2</span>
+            <span id="explorer-count">🔭 0/3</span>
           </div>
           <button id="spawn-defender-btn" disabled style="
             width:100%;
@@ -645,6 +648,18 @@
             border-radius:4px;
             cursor:pointer;
           ">⚔ Spawn Attacker (20W, 15S)</button>
+          <button id="spawn-explorer-btn" disabled style="
+            width:100%;
+            padding:6px 4px;
+            font-size:11px;
+            font-family:'Courier New',monospace;
+            background:#2a2a4a;
+            color:#cccccc;
+            border:1px solid #444466;
+            border-radius:4px;
+            cursor:pointer;
+            margin-top:4px;
+          ">🔭 Spawn Explorer (12W, 8S)</button>
         </div>
         <div class="hud-section" id="section-day-phase">
           <h3>Time of Day</h3>

--- a/client/src/renderer/CreatureRenderer.ts
+++ b/client/src/renderer/CreatureRenderer.ts
@@ -32,6 +32,7 @@ const CARNIVORE_COLOR = 0xf44336;
 const BUILDER_COLOR = 0x42a5f5;
 const DEFENDER_COLOR = 0x2196f3;
 const ATTACKER_COLOR = 0xff9800;
+const EXPLORER_COLOR = 0x66bb6a;
 
 // Brighter variants for Eat state
 const HERBIVORE_EAT_COLOR = 0x81c784;
@@ -122,7 +123,7 @@ export class CreatureRenderer {
 
         const isBuilder = creatureType === 'pawn_builder';
         const isLocalBuilder = isBuilder && ownerID === this.localSessionId;
-        const isCombatEntity = !isGrave && (isEnemyBase(creatureType) || isEnemyMobile(creatureType) || creatureType === 'pawn_defender' || creatureType === 'pawn_attacker');
+        const isCombatEntity = !isGrave && (isEnemyBase(creatureType) || isEnemyMobile(creatureType) || creatureType === 'pawn_defender' || creatureType === 'pawn_attacker' || creatureType === 'pawn_explorer');
 
         let entry = this.entries.get(id);
         if (!entry) {
@@ -336,6 +337,7 @@ export class CreatureRenderer {
     // Combat pawn icons from PAWN_TYPES registry
     if (creatureType === 'pawn_defender') return PAWN_TYPES['defender']?.icon ?? '🛡';
     if (creatureType === 'pawn_attacker') return PAWN_TYPES['attacker']?.icon ?? '⚔';
+    if (creatureType === 'pawn_explorer') return PAWN_TYPES['explorer']?.icon ?? '🔭';
     // Enemy base icons from ENEMY_BASE_TYPES registry
     if (isEnemyBase(creatureType)) return ENEMY_BASE_TYPES[creatureType]?.icon ?? '⛺';
     // Enemy mobile icons from ENEMY_MOBILE_TYPES registry
@@ -353,6 +355,9 @@ export class CreatureRenderer {
         alpha = currentState === 'exhausted' ? 0.3 : 0.4;
       } else if (creatureType === 'pawn_defender') {
         color = currentState === 'exhausted' ? EXHAUSTED_COLOR : DEFENDER_COLOR;
+        alpha = currentState === 'exhausted' ? 0.3 : 0.4;
+      } else if (creatureType === 'pawn_explorer') {
+        color = currentState === 'exhausted' ? EXHAUSTED_COLOR : EXPLORER_COLOR;
         alpha = currentState === 'exhausted' ? 0.3 : 0.4;
       } else {
         // pawn_attacker
@@ -412,6 +417,12 @@ export class CreatureRenderer {
       return;
     }
     if (creatureType === 'pawn_builder') {
+      indicator.text = '';
+      indicator.visible = false;
+      return;
+    }
+    // Explorer pawn — no state indicator needed
+    if (creatureType === 'pawn_explorer') {
       indicator.text = '';
       indicator.visible = false;
       return;
@@ -494,6 +505,7 @@ export class CreatureRenderer {
     if (isEnemyMobile(creatureType)) return ENEMY_MOBILE_TYPES[creatureType]?.health ?? 20;
     if (creatureType === 'pawn_defender') return PAWN_TYPES['defender']?.health ?? 80;
     if (creatureType === 'pawn_attacker') return PAWN_TYPES['attacker']?.health ?? 60;
+    if (creatureType === 'pawn_explorer') return PAWN_TYPES['explorer']?.health ?? 35;
     return 100;
   }
 

--- a/client/src/ui/HudDOM.ts
+++ b/client/src/ui/HudDOM.ts
@@ -25,11 +25,14 @@ export class HudDOM {
   // Combat panel
   private spawnDefenderBtn: HTMLButtonElement;
   private spawnAttackerBtn: HTMLButtonElement;
+  private spawnExplorerBtn: HTMLButtonElement;
   private defenderCountEl: HTMLElement;
   private attackerCountEl: HTMLElement;
+  private explorerCountEl: HTMLElement;
   private enemyBaseCountEl: HTMLElement;
   private currentDefenderCount = 0;
   private currentAttackerCount = 0;
+  private currentExplorerCount = 0;
   private currentEnemyBaseCount = 0;
 
   /** HQ position for colony interactions. */
@@ -55,11 +58,14 @@ export class HudDOM {
     // Combat panel elements
     this.defenderCountEl = document.getElementById('defender-count')!;
     this.attackerCountEl = document.getElementById('attacker-count')!;
+    this.explorerCountEl = document.getElementById('explorer-count')!;
     this.enemyBaseCountEl = document.getElementById('enemy-base-count')!;
     this.spawnDefenderBtn = document.getElementById('spawn-defender-btn') as HTMLButtonElement;
     this.spawnAttackerBtn = document.getElementById('spawn-attacker-btn') as HTMLButtonElement;
+    this.spawnExplorerBtn = document.getElementById('spawn-explorer-btn') as HTMLButtonElement;
     this.spawnDefenderBtn.addEventListener('click', () => this.onSpawnPawn('defender'));
     this.spawnAttackerBtn.addEventListener('click', () => this.onSpawnPawn('attacker'));
+    this.spawnExplorerBtn.addEventListener('click', () => this.onSpawnPawn('explorer'));
   }
 
   /** Handle spawn builder button click. */
@@ -72,13 +78,18 @@ export class HudDOM {
     this.room.send('spawn_pawn', { pawnType: 'builder' });
   }
 
-  /** Handle spawn defender/attacker button click. */
-  private onSpawnPawn(pawnType: 'defender' | 'attacker'): void {
+  /** Handle spawn defender/attacker/explorer button click. */
+  private onSpawnPawn(pawnType: 'defender' | 'attacker' | 'explorer'): void {
     if (!this.room) return;
     const def = PAWN_TYPES[pawnType];
     if (!def) return;
     if (this.currentWood < def.cost.wood || this.currentStone < def.cost.stone) return;
-    const count = pawnType === 'defender' ? this.currentDefenderCount : this.currentAttackerCount;
+    let count: number;
+    switch (pawnType) {
+      case 'defender': count = this.currentDefenderCount; break;
+      case 'attacker': count = this.currentAttackerCount; break;
+      case 'explorer': count = this.currentExplorerCount; break;
+    }
     if (count >= def.maxCount) return;
     this.room.send('spawn_pawn', { pawnType });
   }
@@ -104,6 +115,13 @@ export class HudDOM {
     if (atkDef) {
       const canAffordAtk = this.currentWood >= atkDef.cost.wood && this.currentStone >= atkDef.cost.stone;
       this.spawnAttackerBtn.disabled = !canAffordAtk || this.currentAttackerCount >= atkDef.maxCount;
+    }
+
+    // Explorer button
+    const expDef = PAWN_TYPES['explorer'];
+    if (expDef) {
+      const canAffordExp = this.currentWood >= expDef.cost.wood && this.currentStone >= expDef.cost.stone;
+      this.spawnExplorerBtn.disabled = !canAffordExp || this.currentExplorerCount >= expDef.maxCount;
     }
   }
 
@@ -175,6 +193,7 @@ export class HudDOM {
         let builders = 0;
         let defenders = 0;
         let attackers = 0;
+        let explorers = 0;
         let enemyBases = 0;
         creatures.forEach((creature) => {
           const t = (creature['creatureType'] as string) ?? 'herbivore';
@@ -185,6 +204,8 @@ export class HudDOM {
             defenders++;
           } else if (t === 'pawn_attacker' && ownerID === this.localSessionId) {
             attackers++;
+          } else if (t === 'pawn_explorer' && ownerID === this.localSessionId) {
+            explorers++;
           } else if (t === 'carnivore') {
             carns++;
           } else if (t === 'herbivore') {
@@ -199,11 +220,14 @@ export class HudDOM {
         // Combat counts
         const defDef = PAWN_TYPES['defender'];
         const atkDef = PAWN_TYPES['attacker'];
+        const expDef = PAWN_TYPES['explorer'];
         this.currentDefenderCount = defenders;
         this.currentAttackerCount = attackers;
+        this.currentExplorerCount = explorers;
         this.currentEnemyBaseCount = enemyBases;
         this.defenderCountEl.textContent = `🛡 ${defenders}/${defDef?.maxCount ?? 3}`;
         this.attackerCountEl.textContent = `⚔ ${attackers}/${atkDef?.maxCount ?? 2}`;
+        this.explorerCountEl.textContent = `🔭 ${explorers}/${expDef?.maxCount ?? 3}`;
         this.enemyBaseCountEl.textContent = enemyBases > 0 ? `⛺ ${enemyBases} active` : 'No threats';
 
         this.updateSpawnButton();

--- a/server/src/rooms/creatureAI.ts
+++ b/server/src/rooms/creatureAI.ts
@@ -2,6 +2,7 @@ import { GameState, CreatureState } from "./GameState.js";
 import { stepBuilder } from "./builderAI.js";
 import { stepDefender } from "./defenderAI.js";
 import { stepAttacker } from "./attackerAI.js";
+import { stepExplorer } from "./explorerAI.js";
 import type { AttackerTracker } from "./attackerAI.js";
 import { stepEnemyBase } from "./enemyBaseAI.js";
 import type { EnemyBaseTracker } from "./enemyBaseAI.js";
@@ -95,6 +96,8 @@ export function tickCreatureAI(
       moved = stepDefender(creature, state);
     } else if (creature.pawnType === "attacker") {
       moved = stepAttacker(creature, state, attackerState);
+    } else if (creature.pawnType === "explorer") {
+      moved = stepExplorer(creature, state);
     } else if (creature.creatureType === "pawn_builder") {
       const prevX = creature.x;
       const prevY = creature.y;
@@ -413,6 +416,9 @@ export function isTileOpenForCreature(state: GameState, creature: CreatureState,
 
   // Attackers can enter any walkable tile
   if (creature.pawnType === "attacker") return true;
+
+  // Explorers can enter any walkable tile (they roam freely to scout)
+  if (creature.pawnType === "explorer") return true;
 
   // Defenders: own territory or unclaimed (cannot enter enemy-owned tiles)
   if (creature.pawnType === "defender") {

--- a/server/src/rooms/explorerAI.ts
+++ b/server/src/rooms/explorerAI.ts
@@ -1,0 +1,67 @@
+import { GameState, CreatureState } from "./GameState.js";
+import { isTileOpenForCreature } from "./creatureAI.js";
+
+/**
+ * Explorer pawn FSM: idle → wander
+ * Explorers roam the map autonomously, biased toward unclaimed/unowned tiles.
+ * Their large vision radius reveals fog of war for the owning player.
+ */
+export function stepExplorer(creature: CreatureState, state: GameState): boolean {
+  switch (creature.currentState) {
+    case "idle":
+      creature.currentState = "wander";
+      return false;
+
+    case "wander":
+      return wanderExplore(creature, state);
+
+    default:
+      creature.currentState = "wander";
+      return false;
+  }
+}
+
+/**
+ * Wander with bias toward unclaimed tiles (tiles not owned by any player).
+ * Shuffles cardinal directions, then scores candidates: unclaimed tiles get
+ * priority over owned tiles, encouraging the explorer toward the frontier.
+ */
+function wanderExplore(creature: CreatureState, state: GameState): boolean {
+  const dirs: [number, number][] = [[0, -1], [0, 1], [-1, 0], [1, 0]];
+
+  // Shuffle directions for randomness
+  for (let i = dirs.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
+  }
+
+  // Score each candidate: prefer unclaimed tiles
+  let bestX = -1;
+  let bestY = -1;
+  let bestScore = -1;
+
+  for (const [dx, dy] of dirs) {
+    const nx = creature.x + dx;
+    const ny = creature.y + dy;
+    if (!isTileOpenForCreature(state, creature, nx, ny)) continue;
+
+    const tile = state.getTile(nx, ny);
+    if (!tile) continue;
+
+    // Unclaimed tiles score higher — explorer prefers the frontier
+    const score = tile.ownerID === "" ? 2 : 1;
+    if (score > bestScore) {
+      bestScore = score;
+      bestX = nx;
+      bestY = ny;
+    }
+  }
+
+  if (bestX >= 0 && bestY >= 0) {
+    creature.x = bestX;
+    creature.y = bestY;
+    return true;
+  }
+
+  return false;
+}

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -243,6 +243,21 @@ export const PAWN_TYPES: Record<string, PawnTypeDef> = {
     exhaustedThreshold: 5,
     visionRadius: 5,
   },
+  explorer: {
+    name: "Explorer",
+    icon: "🔭",
+    creatureType: "pawn_explorer",
+    health: 35,
+    cost: { wood: 12, stone: 8 },
+    maxCount: 3,
+    damage: 0,
+    detectionRadius: 0,
+    maxStamina: 30,
+    staminaCostPerMove: 1,
+    staminaRegenPerTick: 2,
+    exhaustedThreshold: 5,
+    visionRadius: 6,
+  },
 };
 
 /** Grave marker constants. */


### PR DESCRIPTION
## Summary

Add a new **Explorer** pawn type that players can spawn to scout the map. The Explorer wanders autonomously with a bias toward unclaimed tiles, revealing fog of war within a 6-tile vision radius (largest of any pawn).

### Changes

- **`shared/src/constants.ts`** — Added `explorer` to `PAWN_TYPES` registry (35 HP, 12W/8S cost, vision radius 6, max 3 per player, 🔭 icon)
- **`server/src/rooms/explorerAI.ts`** — New AI module with wander FSM biased toward frontier (unclaimed) tiles
- **`server/src/rooms/creatureAI.ts`** — Added explorer AI dispatch + tile accessibility (explorers roam freely like attackers)
- **`client/index.html`** — Added spawn button and counter to Combat HUD section
- **`client/src/ui/HudDOM.ts`** — Added explorer spawn handler, creature counting, and button state management
- **`client/src/renderer/CreatureRenderer.ts`** — Added explorer icon, color (green 0x66bb6a), HP bar, and state rendering

### Design Decisions

- **Vision radius 6** — Larger than builders/defenders (4) and attackers (5) since scouting is the Explorer's purpose
- **Low HP (35)** — Fragile scout, not a fighter. Cheapest pawn to lose
- **Free roaming** — Can enter any walkable tile (like attackers), not restricted to owned territory
- **Frontier bias** — Wander algorithm scores unclaimed tiles higher than owned tiles, pushing explorers toward unexplored areas
- **No visibility.ts changes needed** — The existing FOW system auto-discovers pawn types via `PAWN_TYPES` registry

### Testing

695/696 tests pass. The single failure is a pre-existing flaky performance test (`map generation completes in under 500ms`) unrelated to this change.

Working as Pemulis (Systems Dev)

Closes #59