### PR TITLE
Fix phantom buildings in fog-of-war tiles

### DIFF
--- a/client/src/renderer/GridRenderer.ts
+++ b/client/src/renderer/GridRenderer.ts
@@ -385,6 +385,9 @@ export class GridRenderer {
         if (!currentVisible.has(prevIdx)) {
           const px = prevIdx % this.mapSize;
           const py = Math.floor(prevIdx / this.mapSize);
+          // Hide building icon so it doesn't bleed through the semi-transparent fog
+          const bldgIcon = this.buildingIcons.get(prevIdx);
+          if (bldgIcon) bldgIcon.visible = false;
           this.setFogState(px, py, 'explored');
         }
       }
@@ -439,6 +442,10 @@ export class GridRenderer {
           if (icon.text !== expected) icon.text = expected;
         }
         icon.visible = true;
+      } else {
+        // No structure in cache — hide any stale fog silhouette icon
+        const icon = this.fogStructureIcons.get(idx);
+        if (icon) icon.visible = false;
       }
     } else {
       // Unexplored — solid black


### PR DESCRIPTION
Closes #128

Working as Gately (Game Dev)

## Problem

Fog-of-war tiles displayed phantom buildings — structure icons that didn't correspond to actual server-side structures. Two rendering bugs combined to produce this visual artifact.

## Root Cause

1. **Building icon bleed-through:** When tiles transitioned from visible → explored (fog), building icons on `buildingContainer` were not hidden. Since the fog overlay is semi-transparent (alpha 0.6), the full-opacity building icons bled through, showing structures that may have been destroyed server-side while the tile was out of the player's view.

2. **Missing stale icon cleanup:** In `setFogState('explored')`, when the explored cache had no `structureType` for a tile, any existing fog structure silhouette icon was not explicitly hidden — potentially leaving stale silhouette icons visible in edge cases.

## Fix

- Hide building icons in the visible→explored transition loop (lines 388-390)
- Add `else` branch in `setFogState('explored')` to hide fog structure icons when cache has no structure data (lines 445-448)

## Testing

All 792 passing tests continue to pass (2 pre-existing timeout failures in unrelated server tests: `auth-provider` and `water-depth`).