### PR TITLE
fix: spread pawn movement to prevent clustering (#127)

### DIFF
--- a/server/src/rooms/builderAI.ts
+++ b/server/src/rooms/builderAI.ts
@@ -136,11 +136,37 @@ function isInteriorGap(
 }
 
 /**
+ * Collect the set of tiles already targeted by other same-owner builders,
+ * so we can avoid sending multiple pawns to the same location.
+ */
+function getReservedTargets(
+  creature: CreatureState,
+  state: GameState,
+): Set<string> {
+  const reserved = new Set<string>();
+  state.creatures.forEach((other) => {
+    if (
+      other !== creature &&
+      other.ownerID === creature.ownerID &&
+      other.pawnType === "builder" &&
+      other.targetX >= 0 &&
+      other.targetY >= 0
+    ) {
+      reserved.add(`${other.targetX},${other.targetY}`);
+    }
+  });
+  return reserved;
+}
+
+/**
  * Find the best unclaimed walkable tile adjacent to the builder's owner's territory.
  * Scans within BUILD_SITE_SCAN_RADIUS.
  * Prioritizes interior gaps (tiles surrounded on 3+ sides by owned territory)
  * before expanding outward. Within each priority tier, prefers closest tiles
  * with a tiebreaker favoring outward expansion (further from HQ).
+ *
+ * Skips tiles already targeted by other same-owner builders to prevent
+ * multiple pawns from clustering toward the same destination.
  */
 function findBuildSite(
   creature: CreatureState,
@@ -148,6 +174,7 @@ function findBuildSite(
 ): { x: number; y: number } | null {
   const radius = PAWN.BUILD_SITE_SCAN_RADIUS;
   const player = state.players.get(creature.ownerID);
+  const reserved = getReservedTargets(creature, state);
   let best: { x: number; y: number } | null = null;
   let bestDist = Infinity;
   let bestHqDist = -1;
@@ -162,6 +189,7 @@ function findBuildSite(
       if (tile.ownerID !== "") continue;
       if (!isValidBuildTile(tile)) continue;
       if (!isAdjacentToTerritory(state, creature.ownerID, tx, ty)) continue;
+      if (reserved.has(`${tx},${ty}`)) continue;
 
       const dist = Math.abs(dx) + Math.abs(dy);
       if (dist === 0) continue;


### PR DESCRIPTION
## Summary

Builder pawns were clustering together because findBuildSite() in builderAI.ts had no awareness of other pawns' targets. Multiple builders would independently select the identical best tile, then move toward it in lockstep.

## Fix

Added getReservedTargets() — collects tiles already targeted by same-owner builders into a Set. findBuildSite() now skips reserved tiles, ensuring each builder picks a distinct destination.

- **1 file changed:** server/src/rooms/builderAI.ts
- **No new dependencies or schema changes**
- **O(N) cost** where N = builders per player (max 5) — negligible

## Testing

All 738 existing tests pass with no regressions.

Closes #127

Working as Pemulis (Systems Dev)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>