### PR TITLE
fix: resolve pawn clustering root causes across all pawn types (#127)

### DIFF
--- a/.squad/agents/hal/history.md
+++ b/.squad/agents/hal/history.md
@@ -956,3 +956,39 @@ Clean, well-tested implementation. Bootstrap reconnect-check handles all edge ca
 
 Used Gemini 3 Pro for this review task to leverage an alternate model for independent validation perspective. Model performed well on procedural code review.
 
+
+### PRs Reviewed & Approved (Wave 2)
+
+| PR | Author | Issue | Work | Status |
+|----|--------|-------|------|--------|
+| #132 | Marathe | #120 | Changelog generation script | ✅ APPROVED |
+| #133 | Pemulis | #127 | Builder pawn clustering fix | 🔴 REQUEST CHANGES |
+| #134 | Gately | #125 | Outpost rendering & builder stability | ✅ APPROVED |
+
+### Review Findings
+
+- **PR #132 (Changelog)**: Excellent consolidation of shell logic. Moving to a dedicated script reduces duplication across 3 workflows.
+- **PR #133 vs #134 (Builder Logic)**: Both PRs attempted to fix builder clustering by checking `pawnType` or `creatureType`. #134 was superior because it also checked `currentState` (move_to_site/building), preventing idle builders from falsely reserving tiles. I requested changes on #133 in favor of #134.
+- **Rendering**: #134 correctly handles outpost icon visibility in fog-of-war, preventing "ghost" icons.
+
+## Learnings
+
+- Always check `currentState` when filtering pawns for reservation logic — idle pawns can have stale targets.
+- Prefer integer-based tile indices (`y * width + x`) over string coordinates (`"x,y"`) for performance in tight loops.
+
+### PRs Reviewed & Approved (Wave 3)
+
+| PR | Author | Issue | Work | Status |
+|----|--------|-------|------|--------|
+| #129 | Marathe | #122 | Stage label swap automation (dev→uat) | ✅ APPROVED |
+| #130 | Gately | #128 | Fix phantom buildings in fog-of-war | ✅ APPROVED |
+| #131 | Pemulis | #126 | Fix map size timeout for non-128x128 maps | ✅ APPROVED |
+
+### Review Findings
+
+- **PR #129 (Stage Labels)**: Clean job split with branch conditions. Correctly handles label removal (404-safe) and addition. Added `contents: read` permission for checkout — appropriate.
+- **PR #130 (Phantom Buildings)**: Surgical two-line fix. Hides building icons on visible→explored transition and clears stale fog silhouette icons. Good root-cause analysis in PR description. No tests needed — rendering layer.
+- **PR #131 (Map Size Timeout)**: Three-pronged fix (buffer, error handling, timeout). Encoder buffer increase from 768KB to 4MB is proportional to 4x tile count. Try-catch in LobbyRoom uses existing `sendError` pattern. Tests cover 64×64 and 256×256 with correctness + perf ceilings. `package-lock.json` changes are formatting-only (version field relocation).
+
+- Encoder.BUFFER_SIZE now at 4 MB — ceiling for 256×256 maps. If larger maps are ever introduced, this needs revisiting.
+- Client-side game creation timeout is now 30s (was 15s). LobbyScreen.ts line 216.

--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1941,3 +1941,14 @@ Classic "greedy allocation without coordination" pattern. Multiple agents runnin
 - Steeply's 19 anticipatory tests for pawn clustering validation
 - Gately's concurrent outpost fix (shares `getReservedTargets()` pattern)
 
+
+### Pawn Anti-Clustering — Root Cause Fix (2026-03-12)
+
+- **Problem:** PR #134's `getReservedTiles()` prevented same-tile builder targeting but clustering persisted. Four deeper root causes identified:
+  1. **Builder proximity clustering:** `findBuildSite` only excluded exact-tile matches. Builders at similar positions picked adjacent tiles, visually clustering. Fixed with `MIN_BUILDER_SEPARATION = 3` as soft priority in site scoring via `getReservedTargets()`.
+  2. **Movement stacking:** `moveToward()` had no collision avoidance — multiple pawns stacked on same tile. Fixed with `hasFriendlyPawnAt()` soft preference (pawns prefer unoccupied tiles, fall back if all occupied). Wildlife unaffected.
+  3. **Attacker convergence:** `findNearestEnemyTarget` returned same target for all attackers. Fixed with claimed-target tracking — prefer unclaimed targets, fall back to claimed.
+  4. **Explorer convergence:** `wanderExplore` had frontier bias but no mutual avoidance. Fixed with proximity repulsion scoring (tiles near other explorers get lower score).
+- **Architecture pattern:** Soft-preference anti-clustering (never hard-blocks movement, prevents deadlocks). All 790 tests pass.
+- **Key files:** `builderAI.ts`, `creatureAI.ts`, `attackerAI.ts`, `explorerAI.ts`
+- **Branch:** `squad/127-fix-pawn-clustering-root-causes`

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2740,3 +2740,28 @@ Changelog generation is now centralized in `.github/scripts/generate-changelog.s
 
 - Any new workflow that generates changelogs should call `.github/scripts/generate-changelog.sh` instead of writing inline logic.
 - Commit message conventions matter more now — `feat:`, `fix:`, `chore:` prefixes directly affect changelog quality.
+
+---
+
+## 2026-03-11T12-43-00Z: Builder Reservation Logic
+
+**Author:** Hal (Lead)  
+**Date:** 2026-03-11  
+**Status:** Accepted  
+**PRs:** #133 (closed), #134 (approved)
+
+### Decision
+
+Builder pawns now reserve their target tiles using the pattern from PR #134:
+1. Check `creatureType` (or `pawnType`)
+2. **Check `currentState`** (`move_to_site`, `building`) — crucial to filter out idle pawns
+3. Use integer tile indices (`Set<number>`) instead of strings
+
+### Rationale
+
+Two PRs (#133, #134) implemented competing solutions for preventing multiple builders from targeting the same tile. PR #134's approach is state-aware and handles idle pawns correctly.
+
+### Consequences
+- PR #133 has been closed (superseded by #134)
+- Future pawn logic should follow this state-aware pattern when coordinating target selection
+- The pattern is safe for defenders and attackers if they ever independently select from a shared pool

--- a/.squad/decisions/inbox/copilot-directive-no-promotion-prs.md
+++ b/.squad/decisions/inbox/copilot-directive-no-promotion-prs.md
@@ -1,0 +1,4 @@
+### 2026-03-11T12:57:00Z: User directive
+**By:** Copilot (via Copilot)
+**What:** Never initiate PRs into uat or prod autonomously. Promotion PRs are human-initiated only.
+**Why:** User request — captured for team memory

--- a/.squad/decisions/inbox/pemulis-pawn-anti-clustering-pattern.md
+++ b/.squad/decisions/inbox/pemulis-pawn-anti-clustering-pattern.md
@@ -1,0 +1,26 @@
+# Decision: Soft-Preference Anti-Clustering for All Pawn Types
+
+**Author:** Pemulis  
+**Date:** 2026-03-12  
+**Status:** Implemented  
+
+## Context
+
+PR #134 added `getReservedTiles()` to prevent builders from targeting the same tile. Clustering persisted because:
+1. Builders picked adjacent tiles (not just the same tile)
+2. `moveToward()` let pawns stack on the same tile
+3. Attackers all targeted the same enemy
+4. Explorers converged on the same frontier
+
+## Decision
+
+All pawn anti-clustering uses **soft preferences**, never hard blocks:
+- Target reservation: deprioritize (don't exclude) nearby targets when better options exist
+- Movement: prefer unoccupied tiles but always fall back to any valid tile
+- This prevents deadlocks in narrow corridors or small territories
+
+## Implications
+
+- Any new pawn type should follow this pattern: check `hasFriendlyPawnAt()` during movement, add target-spreading to selection logic
+- `moveToward()` now has different behavior for pawns vs wildlife — wildlife takes first valid move, pawns try unoccupied first
+- Performance: O(P) per pawn per movement candidate where P = same-owner pawns. Negligible for max ~13 pawns per player

--- a/.squad/skills/target-reservation/SKILL.md
+++ b/.squad/skills/target-reservation/SKILL.md
@@ -37,4 +37,12 @@ O(N) where N = number of same-team agents. For Primal Grid's max-5 builders, neg
 
 ## Applied In
 
-- `server/src/rooms/builderAI.ts` — PR #133, Issue #127
+- `server/src/rooms/builderAI.ts` — PR #133, Issue #127 (exact-tile reservation)
+- `server/src/rooms/builderAI.ts` — Issue #127 follow-up (proximity-aware reservation with `MIN_BUILDER_SEPARATION`)
+- `server/src/rooms/attackerAI.ts` — attacker target distribution (claimed-target deprioritization)
+- `server/src/rooms/creatureAI.ts` — movement collision avoidance via `hasFriendlyPawnAt()` (soft preference)
+- `server/src/rooms/explorerAI.ts` — explorer mutual repulsion scoring
+
+## Anti-Pattern: Hard Blocks
+
+Never hard-block movement based on friendly pawn presence. Use **soft preferences** — try unoccupied tiles first, fall back to occupied if no alternatives. Hard blocks cause deadlocks when pawns cluster in narrow corridors.

--- a/server/src/rooms/attackerAI.ts
+++ b/server/src/rooms/attackerAI.ts
@@ -130,14 +130,28 @@ export function stepAttacker(
   }
 }
 
-/** Find nearest enemy base or enemy mobile. Prefers bases. */
+/** Find nearest enemy base or enemy mobile. Prefers bases. Deprioritizes targets
+ *  already pursued by another same-owner attacker to encourage target spreading. */
 function findNearestEnemyTarget(
   creature: CreatureState,
   state: GameState,
   detectionRadius: number,
 ): { x: number; y: number; id: string } | null {
+  // Collect positions already pursued by other same-owner attackers
+  const claimedKeys = new Set<string>();
+  state.creatures.forEach((other) => {
+    if (other.id === creature.id) return;
+    if (other.pawnType !== "attacker") return;
+    if (other.ownerID !== creature.ownerID) return;
+    if (other.targetX < 0 || other.targetY < 0) return;
+    if (other.currentState !== "move_to_target" && other.currentState !== "attacking") return;
+    claimedKeys.add(`${other.targetX},${other.targetY}`);
+  });
+
   let nearestBase: { x: number; y: number; id: string; dist: number } | null = null;
   let nearestMobile: { x: number; y: number; id: string; dist: number } | null = null;
+  let nearestClaimedBase: { x: number; y: number; id: string; dist: number } | null = null;
+  let nearestClaimedMobile: { x: number; y: number; id: string; dist: number } | null = null;
 
   state.creatures.forEach((other) => {
     if (other.id === creature.id || other.health <= 0) return;
@@ -147,20 +161,33 @@ function findNearestEnemyTarget(
     // Only consider targets within detection radius
     if (dist > detectionRadius) return;
 
+    const claimed = claimedKeys.has(`${other.x},${other.y}`);
+
     if (isEnemyBase(other.creatureType)) {
-      if (!nearestBase || dist < nearestBase.dist) {
-        nearestBase = { x: other.x, y: other.y, id: other.id, dist };
+      if (claimed) {
+        if (!nearestClaimedBase || dist < nearestClaimedBase.dist) {
+          nearestClaimedBase = { x: other.x, y: other.y, id: other.id, dist };
+        }
+      } else {
+        if (!nearestBase || dist < nearestBase.dist) {
+          nearestBase = { x: other.x, y: other.y, id: other.id, dist };
+        }
       }
     } else if (isEnemyMobile(other.creatureType)) {
-      if (!nearestMobile || dist < nearestMobile.dist) {
-        nearestMobile = { x: other.x, y: other.y, id: other.id, dist };
+      if (claimed) {
+        if (!nearestClaimedMobile || dist < nearestClaimedMobile.dist) {
+          nearestClaimedMobile = { x: other.x, y: other.y, id: other.id, dist };
+        }
+      } else {
+        if (!nearestMobile || dist < nearestMobile.dist) {
+          nearestMobile = { x: other.x, y: other.y, id: other.id, dist };
+        }
       }
     }
   });
 
-  // Prefer bases over mobiles
-  if (nearestBase) return nearestBase;
-  return nearestMobile;
+  // Prefer unclaimed targets, then fall back to already-claimed ones
+  return nearestBase ?? nearestMobile ?? nearestClaimedBase ?? nearestClaimedMobile;
 }
 
 /** Find a creature at the given tile position. */

--- a/server/src/rooms/builderAI.ts
+++ b/server/src/rooms/builderAI.ts
@@ -135,15 +135,19 @@ function isInteriorGap(
   return ownedNeighbors >= 3;
 }
 
+/** Minimum Manhattan distance between builder targets to reduce clustering. */
+const MIN_BUILDER_SEPARATION = 3;
+
 /**
- * Collect the set of tiles already targeted by other builders of the same owner.
- * Prevents multiple builders from converging on the same tile.
+ * Collect positions already targeted by other builders of the same owner.
+ * Returns both exact indices (for exclusion) and coordinate pairs (for proximity checks).
  */
-function getReservedTiles(
+function getReservedTargets(
   creature: CreatureState,
   state: GameState,
-): Set<number> {
+): { reserved: Set<number>; positions: { x: number; y: number }[] } {
   const reserved = new Set<number>();
+  const positions: { x: number; y: number }[] = [];
   state.creatures.forEach((other: CreatureState) => {
     if (other.id === creature.id) return;
     if (other.creatureType !== "pawn_builder") return;
@@ -151,16 +155,18 @@ function getReservedTiles(
     if (other.targetX < 0 || other.targetY < 0) return;
     if (other.currentState !== "move_to_site" && other.currentState !== "building") return;
     reserved.add(other.targetY * state.mapWidth + other.targetX);
+    positions.push({ x: other.targetX, y: other.targetY });
   });
-  return reserved;
+  return { reserved, positions };
 }
 
 /**
  * Find the best unclaimed walkable tile adjacent to the builder's owner's territory.
  * Scans within BUILD_SITE_SCAN_RADIUS.
  * Prioritizes interior gaps (tiles surrounded on 3+ sides by owned territory)
- * before expanding outward. Within each priority tier, prefers closest tiles
- * with a tiebreaker favoring outward expansion (further from HQ).
+ * before expanding outward. Within each priority tier, prefers tiles that are
+ * spatially separated from other builders' targets (MIN_BUILDER_SEPARATION),
+ * then closest tiles with a tiebreaker favoring outward expansion (further from HQ).
  * Skips tiles already targeted by another builder of the same owner.
  */
 function findBuildSite(
@@ -169,11 +175,12 @@ function findBuildSite(
 ): { x: number; y: number } | null {
   const radius = PAWN.BUILD_SITE_SCAN_RADIUS;
   const player = state.players.get(creature.ownerID);
-  const reserved = getReservedTiles(creature, state);
+  const { reserved, positions: reservedPositions } = getReservedTargets(creature, state);
   let best: { x: number; y: number } | null = null;
   let bestDist = Infinity;
   let bestHqDist = -1;
   let bestIsGap = false;
+  let bestNearReserved = true;
 
   for (let dy = -radius; dy <= radius; dy++) {
     for (let dx = -radius; dx <= radius; dx++) {
@@ -196,16 +203,22 @@ function findBuildSite(
         ? Math.abs(tx - player.hqX) + Math.abs(ty - player.hqY)
         : 0;
 
-      // Interior gaps always beat non-gaps; within same tier, prefer closer,
-      // then further from HQ (outward expansion bias as secondary tiebreaker)
+      // Check proximity to other builders' targets — prefer spatially spread tiles
+      const nearReserved = reservedPositions.some(
+        (r) => Math.abs(tx - r.x) + Math.abs(ty - r.y) < MIN_BUILDER_SEPARATION,
+      );
+
+      // Priority (descending): gap > spatially spread > closer to builder > further from HQ
       if (
         (gap && !bestIsGap) ||
-        (gap === bestIsGap && dist < bestDist) ||
-        (gap === bestIsGap && dist === bestDist && hqDist > bestHqDist)
+        (gap === bestIsGap && !nearReserved && bestNearReserved) ||
+        (gap === bestIsGap && nearReserved === bestNearReserved && dist < bestDist) ||
+        (gap === bestIsGap && nearReserved === bestNearReserved && dist === bestDist && hqDist > bestHqDist)
       ) {
         bestDist = dist;
         bestHqDist = hqDist;
         bestIsGap = gap;
+        bestNearReserved = nearReserved;
         best = { x: tx, y: ty };
       }
     }

--- a/server/src/rooms/creatureAI.ts
+++ b/server/src/rooms/creatureAI.ts
@@ -266,23 +266,62 @@ function wanderRandom(creature: CreatureState, state: GameState): boolean {
   return false;
 }
 
-/** Greedy Manhattan movement toward target. Returns true if creature moved. */
+/** Greedy Manhattan movement toward target. Returns true if creature moved.
+ *  Pawns avoid stacking on tiles occupied by same-owner pawns when possible. */
 export function moveToward(creature: CreatureState, tx: number, ty: number, state: GameState): boolean {
   const dx = Math.sign(tx - creature.x);
   const dy = Math.sign(ty - creature.y);
 
   // Try primary axis first (larger delta), then secondary
   const candidates = getCandidateMoves(dx, dy);
+
+  const avoidFriendly = creature.pawnType !== "";
+  let fallbackX = -1;
+  let fallbackY = -1;
+
   for (const [mx, my] of candidates) {
     const nx = creature.x + mx;
     const ny = creature.y + my;
-    if (isTileOpenForCreature(state, creature, nx, ny)) {
+    if (!isTileOpenForCreature(state, creature, nx, ny)) continue;
+
+    if (!avoidFriendly) {
+      creature.x = nx;
+      creature.y = ny;
+      return true;
+    }
+
+    // For pawns: save first valid move as fallback
+    if (fallbackX < 0) { fallbackX = nx; fallbackY = ny; }
+
+    // Prefer tiles without a friendly pawn
+    if (!hasFriendlyPawnAt(state, creature, nx, ny)) {
       creature.x = nx;
       creature.y = ny;
       return true;
     }
   }
+
+  // All valid tiles had a friendly pawn — take the fallback anyway
+  if (avoidFriendly && fallbackX >= 0) {
+    creature.x = fallbackX;
+    creature.y = fallbackY;
+    return true;
+  }
+
   return false;
+}
+
+/** Check if a same-owner pawn occupies the given tile. */
+function hasFriendlyPawnAt(state: GameState, creature: CreatureState, x: number, y: number): boolean {
+  let found = false;
+  state.creatures.forEach((other) => {
+    if (found) return;
+    if (other.id === creature.id) return;
+    if (other.pawnType === "") return;
+    if (other.ownerID !== creature.ownerID) return;
+    if (other.x === x && other.y === y) found = true;
+  });
+  return found;
 }
 
 /** Greedy Manhattan movement away from threat. Returns true if creature moved. */

--- a/server/src/rooms/explorerAI.ts
+++ b/server/src/rooms/explorerAI.ts
@@ -25,6 +25,7 @@ export function stepExplorer(creature: CreatureState, state: GameState): boolean
  * Wander with bias toward unclaimed tiles (tiles not owned by any player).
  * Shuffles cardinal directions, then scores candidates: unclaimed tiles get
  * priority over owned tiles, encouraging the explorer toward the frontier.
+ * Penalizes tiles near other same-owner explorers to encourage spreading out.
  */
 function wanderExplore(creature: CreatureState, state: GameState): boolean {
   const dirs: [number, number][] = [[0, -1], [0, 1], [-1, 0], [1, 0]];
@@ -35,7 +36,16 @@ function wanderExplore(creature: CreatureState, state: GameState): boolean {
     [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
   }
 
-  // Score each candidate: prefer unclaimed tiles
+  // Collect positions of other same-owner explorers for repulsion
+  const otherExplorers: { x: number; y: number }[] = [];
+  state.creatures.forEach((other) => {
+    if (other.id === creature.id) return;
+    if (other.pawnType !== "explorer") return;
+    if (other.ownerID !== creature.ownerID) return;
+    otherExplorers.push({ x: other.x, y: other.y });
+  });
+
+  // Score each candidate: prefer unclaimed tiles and tiles away from other explorers
   let bestX = -1;
   let bestY = -1;
   let bestScore = -1;
@@ -49,7 +59,14 @@ function wanderExplore(creature: CreatureState, state: GameState): boolean {
     if (!tile) continue;
 
     // Unclaimed tiles score higher — explorer prefers the frontier
-    const score = tile.ownerID === "" ? 2 : 1;
+    let score = tile.ownerID === "" ? 2 : 1;
+
+    // Bonus for tiles away from other same-owner explorers
+    const nearExplorer = otherExplorers.some(
+      (e) => Math.abs(nx - e.x) + Math.abs(ny - e.y) <= 2,
+    );
+    if (!nearExplorer) score += 1;
+
     if (score > bestScore) {
       bestScore = score;
       bestX = nx;


### PR DESCRIPTION
## Summary

Fixes persistent pawn clustering that survived the original `getReservedTiles()` fix in PR #134. That fix only prevented builders from targeting the *exact same tile* — but 4 deeper root causes remained.

### Root Causes & Fixes

**1. Builder proximity clustering** — Builders at similar positions picked tiles 1 apart, visually clustering. Added `MIN_BUILDER_SEPARATION = 3` as a soft priority penalty in site scoring so builders naturally spread out.

**2. Movement stacking** — `moveToward()` had zero collision avoidance. Multiple pawns walked onto the same cell. Added `hasFriendlyPawnAt()` — pawns now prefer unoccupied tiles as a soft preference (never deadlocks movement).

**3. Attacker convergence** — Both attackers targeted the same enemy base. Added claimed-target tracking so the second attacker picks a different target when available.

**4. Explorer convergence** — All explorers biased toward the same frontier tiles. Added proximity repulsion scoring.

All fixes use **soft preferences** (never hard-block movement) to prevent deadlocks.

### Files Changed
- `server/src/rooms/builderAI.ts` — separation scoring in `findBuildSite()`
- `server/src/rooms/creatureAI.ts` — `hasFriendlyPawnAt()` collision avoidance in `moveToward()`
- `server/src/rooms/attackerAI.ts` — claimed-target tracking
- `server/src/rooms/explorerAI.ts` — proximity repulsion

### Testing
All 790 existing tests pass. No new dependencies.

Closes #127