### PR TITLE
Fix flaky tests: outpost-spacing and water-depth

### DIFF
--- a/server/src/__tests__/outpost-spacing.test.ts
+++ b/server/src/__tests__/outpost-spacing.test.ts
@@ -239,6 +239,8 @@ describe("Bug #139 — Outpost Spacing", () => {
       const targetTile = room.state.getTile(targetX, startY);
       if (!targetTile) return;
       targetTile.ownerID = "";
+      targetTile.type = TileType.Grassland;
+      targetTile.shapeHP = 0;
 
       const builder = addBuilder(room, "b1", "p1", startX, startY, {
         currentState: "building",

--- a/server/src/__tests__/water-depth.test.ts
+++ b/server/src/__tests__/water-depth.test.ts
@@ -86,7 +86,7 @@ describe("Water Depth Variants", () => {
   describe("Map generation water distribution", () => {
     const TEST_SEEDS = [42, 100, 256, 777, 9999];
 
-    it("generated maps contain BOTH ShallowWater and DeepWater tiles", () => {
+    it("generated maps contain BOTH ShallowWater and DeepWater tiles", { timeout: 30_000 }, () => {
       for (const seed of TEST_SEEDS) {
         const room = createRoomWithMap(seed);
         let shallow = 0;
@@ -101,7 +101,7 @@ describe("Water Depth Variants", () => {
       }
     });
 
-    it("water tiles exist on the map (not all eliminated by smoothing)", () => {
+    it("water tiles exist on the map (not all eliminated by smoothing)", { timeout: 30_000 }, () => {
       for (const seed of TEST_SEEDS) {
         const room = createRoomWithMap(seed);
         let waterCount = 0;


### PR DESCRIPTION
Fixes two flaky tests identified in UAT CI:

**Fix 1: outpost-spacing test (Priority)**
- The "builder places outpost when far enough from existing outposts" test was failing ~20% of runs
- Root cause: Target tile from generated map could be water/rock, making it unbuildable
- Solution: Explicitly set target tile to Grassland with shapeHP=0 to ensure it's buildable
- This test validates spacing logic, not tile type validation

**Fix 2: water-depth test timeouts**
- Two tests generating multiple maps lacked explicit timeouts
- Added 30s timeout to both "generated maps contain BOTH ShallowWater and DeepWater tiles" and "water tiles exist on the map" tests
- Prevents timeout failures on slow CI runners

**Verification:**
- Ran outpost-spacing test 5 consecutive times ✓
- Full test suite: 857 tests passing ✓

Closes: Issue related to flaky UAT CI tests