### PR TITLE
fix: improve explorer AI movement logic (closes #147)

### DIFF
--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1968,3 +1968,10 @@ Classic "greedy allocation without coordination" pattern. Multiple agents runnin
 **Review:** Hal approved with performance note on `hasFriendlyPawnAt` O(N²) algorithm — acceptable for current scales, monitor.
 
 **Follow-up:** Issue #136 filed for gray blocks rendering bug.
+
+### Explorer AI Frontier Scanning (2026-03-12)
+
+- **Issue:** #147 — Explorers moved randomly when deep inside owned territory because the AI only scored 4 adjacent tiles. When all neighbors are owned, scores tie and movement is aimless.
+- **Fix:** Added `countFrontierInDirection()` — a ray scan (up to 6 tiles, matching vision radius) that counts unclaimed tiles in each cardinal direction. This score bonus steers explorers through owned territory toward the frontier. Also raised unclaimed base score (2→3) and repulsion bonus (1→2).
+- **Tests:** 9 new tests in `explorer-ai.test.ts` — FSM transitions, frontier counting, directed movement through territory, repulsion, fallback.
+- **PR:** #149 on `squad/147-explorer-ai-movement`. 878/878 tests passing.

--- a/.squad/decisions/inbox/pemulis-explorer-frontier-scan.md
+++ b/.squad/decisions/inbox/pemulis-explorer-frontier-scan.md
@@ -1,0 +1,27 @@
+## Explorer AI: Frontier Ray Scanning
+
+**Author:** Pemulis  
+**Date:** 2026-03-12  
+**Status:** Implemented  
+**PR:** #149  
+**Issue:** #147
+
+### Context
+
+Explorers scored only the 4 adjacent tiles. Deep inside owned territory, all neighbors are owned and score equally — resulting in random wandering that doesn't explore.
+
+### Decision
+
+Added a **frontier ray scan** to explorer scoring: for each candidate direction, cast a ray of up to `PAWN_TYPES.explorer.visionRadius` (6) tiles and count unclaimed tiles. This bonus steers explorers through owned territory toward the frontier.
+
+Scoring weights:
+- Unclaimed adjacent tile: +3 (was +2)
+- Owned adjacent tile: +1
+- Unclaimed tiles along ray: +1 each (0-6 range)
+- Away from same-owner explorers: +2 (was +1)
+
+### Implications
+
+- `countFrontierInDirection()` is exported from `explorerAI.ts` for direct testing
+- Performance: O(4 × scan_radius) per explorer per tick — negligible for max 3 explorers per player
+- If future pawn types need frontier awareness, reuse `countFrontierInDirection`

--- a/server/src/__tests__/explorer-ai.test.ts
+++ b/server/src/__tests__/explorer-ai.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Explorer AI — Issue #147
+ *
+ * Tests verify that explorers:
+ * 1. Prefer unclaimed tiles over owned tiles (frontier bias)
+ * 2. Navigate through owned territory toward the frontier (frontier scan)
+ * 3. Spread apart from other same-owner explorers (repulsion)
+ * 4. Fall back to random movement when fully surrounded by owned tiles
+ */
+import { describe, it, expect, vi } from "vitest";
+import { GameState, CreatureState, TileState } from "../rooms/GameState.js";
+import { GameRoom } from "../rooms/GameRoom.js";
+import { stepExplorer, countFrontierInDirection } from "../rooms/explorerAI.js";
+import {
+  TileType, PAWN_TYPES,
+} from "@primal-grid/shared";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function createRoomWithMap(seed?: number): GameRoom {
+  const room = Object.create(GameRoom.prototype) as GameRoom;
+  room.state = new GameState();
+  room.generateMap(seed);
+  room.broadcast = vi.fn();
+  room.playerViews = new Map();
+  return room;
+}
+
+function addExplorer(
+  room: GameRoom,
+  id: string,
+  ownerID: string,
+  x: number,
+  y: number,
+  overrides: Partial<{
+    currentState: string;
+  }> = {},
+): CreatureState {
+  const creature = new CreatureState();
+  creature.id = id;
+  creature.creatureType = "pawn_explorer";
+  creature.x = x;
+  creature.y = y;
+  creature.health = PAWN_TYPES.explorer.health;
+  creature.currentState = overrides.currentState ?? "wander";
+  creature.ownerID = ownerID;
+  creature.pawnType = "explorer";
+  creature.stamina = PAWN_TYPES.explorer.maxStamina;
+  creature.nextMoveTick = 0;
+  room.state.creatures.set(id, creature);
+  return creature;
+}
+
+/** Claim a rectangular region of tiles for a given owner. */
+function claimRegion(
+  state: GameState,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  ownerID: string,
+) {
+  for (let y = y1; y <= y2; y++) {
+    for (let x = x1; x <= x2; x++) {
+      const tile = state.getTile(x, y);
+      if (tile) tile.ownerID = ownerID;
+    }
+  }
+}
+
+/**
+ * Find a walkable position on the map where we can place an explorer
+ * and claim a region around it. Returns the center coordinates.
+ */
+function findWalkableCenter(state: GameState, margin: number = 15): { x: number; y: number } {
+  for (let y = margin; y < state.mapHeight - margin; y++) {
+    for (let x = margin; x < state.mapWidth - margin; x++) {
+      let allWalkable = true;
+      for (let dy = -5; dy <= 5 && allWalkable; dy++) {
+        for (let dx = -5; dx <= 5 && allWalkable; dx++) {
+          if (!state.isWalkable(x + dx, y + dy)) allWalkable = false;
+        }
+      }
+      if (allWalkable) return { x, y };
+    }
+  }
+  return { x: margin, y: margin };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("Explorer AI", () => {
+  describe("stepExplorer FSM transitions", () => {
+    it("transitions from idle to wander", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+      const explorer = addExplorer(room, "e1", "p1", center.x, center.y, {
+        currentState: "idle",
+      });
+
+      stepExplorer(explorer, room.state);
+      expect(explorer.currentState).toBe("wander");
+    });
+
+    it("recovers unknown states to wander", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+      const explorer = addExplorer(room, "e1", "p1", center.x, center.y, {
+        currentState: "bogus_state",
+      });
+
+      stepExplorer(explorer, room.state);
+      expect(explorer.currentState).toBe("wander");
+    });
+  });
+
+  describe("countFrontierInDirection", () => {
+    it("counts unclaimed tiles along a ray", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+
+      // Claim tiles to the west, leave east unclaimed
+      claimRegion(room.state, center.x - 3, center.y, center.x, center.y, "p1");
+
+      const eastCount = countFrontierInDirection(
+        room.state, center.x, center.y, 1, 0, 6,
+      );
+      const westCount = countFrontierInDirection(
+        room.state, center.x, center.y, -1, 0, 6,
+      );
+
+      // East should have more unclaimed tiles than west
+      expect(eastCount).toBeGreaterThan(westCount);
+    });
+
+    it("returns 0 when all tiles in direction are owned", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+
+      // Claim a large region in all directions
+      claimRegion(
+        room.state,
+        center.x - 8, center.y - 8,
+        center.x + 8, center.y + 8,
+        "p1",
+      );
+
+      const count = countFrontierInDirection(
+        room.state, center.x, center.y, 1, 0, 6,
+      );
+      expect(count).toBe(0);
+    });
+
+    it("stops at map boundaries", () => {
+      const room = createRoomWithMap(42);
+
+      // Place at map edge and scan outward
+      const count = countFrontierInDirection(
+        room.state, 0, 0, -1, 0, 6,
+      );
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("frontier-directed movement", () => {
+    it("moves toward unclaimed tiles when at frontier", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+
+      // Claim a large block around and west of center; leave only east unclaimed.
+      // This forces the frontier to be exclusively to the east.
+      claimRegion(
+        room.state,
+        center.x - 8, center.y - 8,
+        center.x, center.y + 8,
+        "p1",
+      );
+
+      const explorer = addExplorer(room, "e1", "p1", center.x, center.y);
+
+      // Run steps — explorer should drift eastward (toward frontier)
+      let eastwardMoves = 0;
+      let totalMoves = 0;
+      for (let i = 0; i < 40; i++) {
+        const prevX = explorer.x;
+        const moved = stepExplorer(explorer, room.state);
+        if (moved) {
+          totalMoves++;
+          if (explorer.x > prevX) eastwardMoves++;
+        }
+      }
+
+      // Explorer should move and frequently head east
+      expect(totalMoves).toBeGreaterThan(0);
+      expect(eastwardMoves).toBeGreaterThan(0);
+    });
+
+    it("navigates through owned territory toward frontier", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+
+      // Claim a narrow band: frontier is within scan range from the start.
+      claimRegion(
+        room.state,
+        center.x - 4, center.y - 4,
+        center.x + 2, center.y + 4,
+        "p1",
+      );
+
+      // Place explorer inside owned territory — frontier (east of x+2) is nearby
+      const explorer = addExplorer(room, "e1", "p1", center.x, center.y);
+      const startX = explorer.x;
+
+      // Track max-x reached over many steps
+      let maxX = startX;
+      for (let i = 0; i < 80; i++) {
+        stepExplorer(explorer, room.state);
+        if (explorer.x > maxX) maxX = explorer.x;
+      }
+
+      // Explorer should have ventured east of its starting position at some point
+      expect(maxX).toBeGreaterThan(startX);
+    });
+  });
+
+  describe("explorer repulsion", () => {
+    it("explorers prefer tiles away from each other", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+
+      // Place two explorers at same position
+      const e1 = addExplorer(room, "e1", "p1", center.x, center.y);
+      const e2 = addExplorer(room, "e2", "p1", center.x, center.y);
+
+      // Run several steps
+      for (let i = 0; i < 30; i++) {
+        stepExplorer(e1, room.state);
+        stepExplorer(e2, room.state);
+      }
+
+      // They should have separated
+      const dist = Math.abs(e1.x - e2.x) + Math.abs(e1.y - e2.y);
+      expect(dist).toBeGreaterThan(0);
+    });
+  });
+
+  describe("fallback behavior", () => {
+    it("still moves when completely surrounded by owned tiles", () => {
+      const room = createRoomWithMap(42);
+      const center = findWalkableCenter(room.state);
+
+      // Claim everything within a large radius
+      claimRegion(
+        room.state,
+        center.x - 10, center.y - 10,
+        center.x + 10, center.y + 10,
+        "p1",
+      );
+
+      const explorer = addExplorer(room, "e1", "p1", center.x, center.y);
+
+      let moved = false;
+      for (let i = 0; i < 10; i++) {
+        if (stepExplorer(explorer, room.state)) moved = true;
+      }
+
+      // Should still move even when no frontier exists
+      expect(moved).toBe(true);
+    });
+  });
+});

--- a/server/src/rooms/explorerAI.ts
+++ b/server/src/rooms/explorerAI.ts
@@ -1,5 +1,9 @@
 import { GameState, CreatureState } from "./GameState.js";
+import { PAWN_TYPES } from "@primal-grid/shared";
 import { isTileOpenForCreature } from "./creatureAI.js";
+
+/** How far ahead an explorer scans to detect frontier tiles. */
+const FRONTIER_SCAN_RADIUS = PAWN_TYPES.explorer.visionRadius;
 
 /**
  * Explorer pawn FSM: idle → wander
@@ -22,15 +26,44 @@ export function stepExplorer(creature: CreatureState, state: GameState): boolean
 }
 
 /**
+ * Count unclaimed tiles along a ray from (fromX, fromY) in direction (dx, dy).
+ * Used to give explorers a sense of which direction leads toward the frontier,
+ * even when all immediately adjacent tiles are owned.
+ */
+export function countFrontierInDirection(
+  state: GameState,
+  fromX: number,
+  fromY: number,
+  dx: number,
+  dy: number,
+  radius: number,
+): number {
+  let count = 0;
+  for (let dist = 1; dist <= radius; dist++) {
+    const tx = fromX + dx * dist;
+    const ty = fromY + dy * dist;
+    const tile = state.getTile(tx, ty);
+    if (!tile) break;
+    if (tile.ownerID === "") count++;
+  }
+  return count;
+}
+
+/**
  * Wander with bias toward unclaimed tiles (tiles not owned by any player).
- * Shuffles cardinal directions, then scores candidates: unclaimed tiles get
- * priority over owned tiles, encouraging the explorer toward the frontier.
- * Penalizes tiles near other same-owner explorers to encourage spreading out.
+ * Shuffles cardinal directions, then scores candidates:
+ *  - Immediate tile: unclaimed = +3, owned = +1
+ *  - Frontier scan: +1 per unclaimed tile in that direction (up to SCAN_RADIUS)
+ *  - Explorer repulsion: +2 if no same-owner explorer within Manhattan distance 2
+ *
+ * The frontier scan is the key improvement: when an explorer is deep inside
+ * owned territory and all adjacent tiles score equally, the scan detects which
+ * direction leads toward unexplored territory and biases movement that way.
  */
 function wanderExplore(creature: CreatureState, state: GameState): boolean {
   const dirs: [number, number][] = [[0, -1], [0, 1], [-1, 0], [1, 0]];
 
-  // Shuffle directions for randomness
+  // Shuffle directions for randomness (tie-breaking when scores are equal)
   for (let i = dirs.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
@@ -45,7 +78,6 @@ function wanderExplore(creature: CreatureState, state: GameState): boolean {
     otherExplorers.push({ x: other.x, y: other.y });
   });
 
-  // Score each candidate: prefer unclaimed tiles and tiles away from other explorers
   let bestX = -1;
   let bestY = -1;
   let bestScore = -1;
@@ -58,14 +90,19 @@ function wanderExplore(creature: CreatureState, state: GameState): boolean {
     const tile = state.getTile(nx, ny);
     if (!tile) continue;
 
-    // Unclaimed tiles score higher — explorer prefers the frontier
-    let score = tile.ownerID === "" ? 2 : 1;
+    // Immediate tile: unclaimed tiles get a strong base score
+    let score = tile.ownerID === "" ? 3 : 1;
 
-    // Bonus for tiles away from other same-owner explorers
+    // Frontier scan: count unclaimed tiles ahead in this direction
+    score += countFrontierInDirection(
+      state, creature.x, creature.y, dx, dy, FRONTIER_SCAN_RADIUS,
+    );
+
+    // Explorer repulsion: prefer tiles away from other same-owner explorers
     const nearExplorer = otherExplorers.some(
       (e) => Math.abs(nx - e.x) + Math.abs(ny - e.y) <= 2,
     );
-    if (!nearExplorer) score += 1;
+    if (!nearExplorer) score += 2;
 
     if (score > bestScore) {
       bestScore = score;


### PR DESCRIPTION
## Summary

Fixes #147 — explorers were moving a lot but not exploring much.

**Root cause:** The explorer AI scored only the 4 immediately adjacent tiles. When deep inside owned territory, all adjacent tiles scored identically (all owned), so movement was pure random shuffling with no directional intent toward the frontier.

**Fix:** Added a frontier scan — for each candidate direction, a ray of up to 6 tiles (matching the explorer's vision radius) counts unclaimed tiles ahead. This gives explorers a sense of which direction leads toward unexplored territory, even when surrounded by owned tiles.

### Changes

- **`server/src/rooms/explorerAI.ts`**: Added `countFrontierInDirection()` ray-scan helper. Raised unclaimed base score (2→3) and repulsion bonus (1→2) for stronger frontier pull. Exported the helper for testability.
- **`server/src/__tests__/explorer-ai.test.ts`**: 9 new tests covering FSM transitions, frontier scan counting, directed movement, explorer repulsion, and fallback behavior.

### Scoring (per adjacent tile)

| Factor | Score |
|--------|-------|
| Unclaimed (immediate) | +3 |
| Owned (immediate) | +1 |
| Unclaimed tiles ahead (ray scan, up to 6) | +1 each |
| Away from same-owner explorers | +2 |

### Test results
878/878 tests passing.

Working as Pemulis (Systems Dev)