### PR TITLE
fix(ci): Discord notifications show current release changelog

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -123,10 +123,11 @@ jobs:
           # Checkout with full history for changelog
           git clone --depth 50 https://github.com/${REPOSITORY}.git repo
           cd repo
-          git fetch --depth 50 origin uat
+          git fetch --depth 50 origin uat prod
 
-          # Generate categorized changelog (features/fixes first, chores excluded)
-          CHANGELOG=$(bash .github/scripts/generate-changelog.sh "HEAD~10..HEAD" --format discord --max-lines 10)
+          # Generate changelog comparing UAT against prod (what's new in UAT)
+          # This shows commits that are in UAT but not yet in prod
+          CHANGELOG=$(bash .github/scripts/generate-changelog.sh "origin/prod..origin/uat" --format discord --max-lines 10)
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="• No recent changes"
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,9 +103,19 @@ jobs:
           git clone --depth 50 https://github.com/${REPOSITORY}.git repo
           cd repo
           git fetch --depth 50 origin prod
+          git fetch --tags
 
-          # Generate categorized changelog (features/fixes first, chores excluded)
-          CHANGELOG=$(bash .github/scripts/generate-changelog.sh "HEAD~10..HEAD" --format discord --max-lines 10)
+          # Generate changelog from last production tag to current HEAD
+          # Find the most recent tag on prod branch
+          LAST_TAG=$(git describe --tags --abbrev=0 origin/prod 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..origin/prod"
+          else
+            # Fallback: compare against prod~10 if no tags exist
+            RANGE="origin/prod~10..origin/prod"
+          fi
+          
+          CHANGELOG=$(bash .github/scripts/generate-changelog.sh "$RANGE" --format discord --max-lines 10)
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="• No recent changes"
           fi

--- a/.squad/agents/marathe/history.md
+++ b/.squad/agents/marathe/history.md
@@ -727,3 +727,69 @@ Issue #120 re-labeled from `squad:pemulis` to `squad:marathe` (release automatio
 - In dev→uat promotions, conflicts are typically version bumps — dev always wins since it's the source being promoted
 - `git merge origin/uat --no-commit` is the right pattern to inspect conflicts before committing
 - Remember: `--ours` = HEAD (current branch), `--theirs` = branch being merged in
+
+## 2026-03-11: Issue #159 — Discord Notifications Show Stale Changelog (Fixed)
+
+**Task:** Fix UAT and prod Discord deployment notifications showing previous release changelog instead of current release changes  
+**Status:** ✅ Completed  
+**Branch:** `squad/159-fix-ci-discord-notify`  
+**PR:** #162 (opened against dev)
+
+### The Bug
+
+Both `deploy-uat.yml` and `deploy.yml` used `HEAD~10..HEAD` for changelog generation, which simply showed the last 10 commits on the branch regardless of what was actually new in this deployment. This resulted in stale/previous release content appearing in Discord notifications.
+
+### Root Cause Analysis
+
+The workflows cloned the repo with `--depth 50` and ran:
+```bash
+CHANGELOG=$(bash .github/scripts/generate-changelog.sh "HEAD~10..HEAD" --format discord --max-lines 10)
+```
+
+Problem: `HEAD~10..HEAD` looks backward from current HEAD without considering what's already been deployed. It shows commits that may have been deployed days/weeks ago.
+
+### Solution
+
+**UAT workflow (deploy-uat.yml):**
+- Changed from: `HEAD~10..HEAD`
+- Changed to: `origin/prod..origin/uat`
+- **Rationale:** Shows commits that are in UAT but not yet promoted to prod — exactly what's new in this UAT deployment
+
+**Production workflow (deploy.yml):**
+- Changed from: `HEAD~10..HEAD`
+- Changed to: `${LAST_TAG}..origin/prod` (falls back to `origin/prod~10..origin/prod` if no tags)
+- **Rationale:** Shows commits from last production release tag to current — exactly what's in this production release
+- Uses `git describe --tags --abbrev=0 origin/prod` to find most recent prod tag
+
+### Technical Details
+
+- Added `git fetch --depth 50 origin prod` to UAT workflow (needed both branches for comparison)
+- Added `git fetch --tags` to prod workflow (needed for tag-based range)
+- Preserved all existing changelog features (categorization, Discord format, 10-line limit, jq escaping)
+- No changes to `generate-changelog.sh` script itself — only the commit range passed to it
+
+### Testing Strategy
+
+- Workflow YAML syntax validated
+- Changelog generation script already battle-tested in production
+- Git range logic verified: `origin/prod..origin/uat` and `${TAG}..origin/prod` both valid
+- Change is surgical: only affects commit range calculation, not notification logic
+
+### Key Learning
+
+**Pattern for deployment changelogs:** Always compare against the target/previous environment, not arbitrary history depth:
+- Dev → UAT: show `origin/dev..origin/uat`
+- UAT → Prod: show `origin/uat..origin/prod` OR `${LAST_PROD_TAG}..origin/prod`
+- Never use `HEAD~N..HEAD` for deployment notifications (shows arbitrary history, not delta)
+
+### Files Modified
+
+- `.github/workflows/deploy-uat.yml` (lines 123-130)
+- `.github/workflows/deploy.yml` (lines 102-118)
+
+### Related
+
+- Issue: #159 (mislabeled as squad:gately, corrected to squad:marathe)
+- Commit: 45b786f
+- PR: #162
+


### PR DESCRIPTION
Closes #159. Fixed UAT and prod Discord notifications to show current release changes instead of stale commits. UAT now compares origin/prod..origin/uat. Prod compares from last tag. Working as Marathe.