### PR TITLE
Resource Tuning: Unit Cost Differentiation & Expensive Farms

### DIFF
--- a/server/src/__tests__/combat-system.test.ts
+++ b/server/src/__tests__/combat-system.test.ts
@@ -892,14 +892,18 @@ describe("Pawn Types — Constants & Registry", () => {
     expect(PAWN_TYPES["attacker"]).toBeDefined();
   });
 
-  it("defender cost is higher than builder cost (wood and stone)", () => {
-    expect(PAWN_TYPES["defender"].cost.wood).toBeGreaterThan(PAWN_TYPES["builder"].cost.wood);
-    expect(PAWN_TYPES["defender"].cost.stone).toBeGreaterThan(PAWN_TYPES["builder"].cost.stone);
-  });
+  it("pawn types have differentiated resource costs for strategic choice", () => {
+    // Builder: wood-focused, cheap stone (economy unit)
+    expect(PAWN_TYPES["builder"].cost.wood).toBe(10);
+    expect(PAWN_TYPES["builder"].cost.stone).toBe(3);
 
-  it("attacker cost is higher than defender cost (wood and stone)", () => {
-    expect(PAWN_TYPES["attacker"].cost.wood).toBeGreaterThan(PAWN_TYPES["defender"].cost.wood);
-    expect(PAWN_TYPES["attacker"].cost.stone).toBeGreaterThan(PAWN_TYPES["defender"].cost.stone);
+    // Defender: stone-heavy, cheap wood (stone-sink defensive unit)
+    expect(PAWN_TYPES["defender"].cost.wood).toBe(8);
+    expect(PAWN_TYPES["defender"].cost.stone).toBe(12);
+
+    // Attacker: expensive wood, moderate stone (costly offensive unit)
+    expect(PAWN_TYPES["attacker"].cost.wood).toBe(18);
+    expect(PAWN_TYPES["attacker"].cost.stone).toBe(10);
   });
 
   it("each pawn type has damage, HP, and maxCount defined", () => {

--- a/server/src/__tests__/food-economy.test.ts
+++ b/server/src/__tests__/food-economy.test.ts
@@ -406,19 +406,19 @@ describe("Food Economy System", () => {
   // ── 10. Rebalanced spawn costs ──────────────────────────────────
 
   describe("rebalanced pawn spawn costs", () => {
-    it("builder costs 8 wood, 4 stone", () => {
-      expect(PAWN_TYPES.builder.cost.wood).toBe(8);
-      expect(PAWN_TYPES.builder.cost.stone).toBe(4);
+    it("builder costs 10 wood, 3 stone", () => {
+      expect(PAWN_TYPES.builder.cost.wood).toBe(10);
+      expect(PAWN_TYPES.builder.cost.stone).toBe(3);
     });
 
-    it("defender costs 12 wood, 8 stone", () => {
-      expect(PAWN_TYPES.defender.cost.wood).toBe(12);
-      expect(PAWN_TYPES.defender.cost.stone).toBe(8);
+    it("defender costs 8 wood, 12 stone", () => {
+      expect(PAWN_TYPES.defender.cost.wood).toBe(8);
+      expect(PAWN_TYPES.defender.cost.stone).toBe(12);
     });
 
-    it("attacker costs 16 wood, 12 stone", () => {
-      expect(PAWN_TYPES.attacker.cost.wood).toBe(16);
-      expect(PAWN_TYPES.attacker.cost.stone).toBe(12);
+    it("attacker costs 18 wood, 10 stone", () => {
+      expect(PAWN_TYPES.attacker.cost.wood).toBe(18);
+      expect(PAWN_TYPES.attacker.cost.stone).toBe(10);
     });
 
     it("explorer costs 10 wood, 6 stone", () => {

--- a/server/src/__tests__/pawnBuilder.test.ts
+++ b/server/src/__tests__/pawnBuilder.test.ts
@@ -171,9 +171,9 @@ function manhattan(x1: number, y1: number, x2: number, y2: number): number {
 describe("Builder spawning (cost, cap, validation)", () => {
 
   // ★ contract — passes before runtime implementation
-  it("spawn cost constants match PAWN_TYPES (8 Wood / 4 Stone)", () => {
-    expect(PAWN_TYPES.builder.cost.wood).toBe(8);
-    expect(PAWN_TYPES.builder.cost.stone).toBe(4);
+  it("spawn cost constants match PAWN_TYPES (10 Wood / 3 Stone)", () => {
+    expect(PAWN_TYPES.builder.cost.wood).toBe(10);
+    expect(PAWN_TYPES.builder.cost.stone).toBe(3);
   });
 
   // ★ contract — passes before runtime implementation

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -212,7 +212,7 @@ export const PAWN_TYPES: Record<string, PawnTypeDef> = {
     icon: "🔨",
     creatureType: "pawn_builder",
     health: 50,
-    cost: { wood: 8, stone: 4 },
+    cost: { wood: 10, stone: 3 },
     foodUpkeep: 1,
     maxCount: 5,
     damage: 0,
@@ -228,7 +228,7 @@ export const PAWN_TYPES: Record<string, PawnTypeDef> = {
     icon: "🛡",
     creatureType: "pawn_defender",
     health: 80,
-    cost: { wood: 12, stone: 8 },
+    cost: { wood: 8, stone: 12 },
     foodUpkeep: 2,
     maxCount: 3,
     damage: 20,
@@ -244,7 +244,7 @@ export const PAWN_TYPES: Record<string, PawnTypeDef> = {
     icon: "⚔",
     creatureType: "pawn_attacker",
     health: 60,
-    cost: { wood: 16, stone: 12 },
+    cost: { wood: 18, stone: 10 },
     foodUpkeep: 3,
     maxCount: 2,
     damage: 25,
@@ -324,7 +324,7 @@ export const STRUCTURE_INCOME = {
 
 /** Building placement costs (instant placement via PLACE_BUILDING). */
 export const BUILDING_COSTS: Record<string, { wood: number; stone: number }> = {
-  farm: { wood: 12, stone: 6 },
+  farm: { wood: 18, stone: 10 },
   factory: { wood: 20, stone: 12 },
 } as const;
 


### PR DESCRIPTION
Closes #156

## Changes

Implements **HIGH-priority** resource tuning changes approved by Hal from issue #156:

### 1. Unit Cost Differentiation
Creates strategic resource identity for each unit type:
- **Builder**: 10W/3S (wood-focused economy unit, cheap stone)
- **Defender**: 8W/12S (stone-heavy defensive unit, cheap wood) 
- **Attacker**: 18W/10S (expensive wood, moderate stone)

This breaks the old linear cost progression (builder < defender < attacker) in favor of differentiated resource profiles. Each unit now has a unique resource identity that creates strategic tension.

### 2. Expensive Farms
- **Farm**: 18W/10S (up from 12W/6S)
- Extends food scarcity phase
- Makes farm placement a real strategic decision
- Forces "farm vs defender" tradeoffs earlier

## Design Rationale

**Old model**: Rigid build order, stone accumulates uselessly
**New model**: Resource types matter. Defender-heavy strategies are stone-starved. Attackers are wood-expensive. Builders are balanced but not trivial.

## Testing

- Updated test assertions to validate new strategic cost structure
- All resource-related tests pass (903 total tests, 2 pre-existing timeout failures unrelated to this change)
- Tests now validate differentiated costs rather than linear ordering

## Deferred Items

Recommendations #3-#5 from the original analysis are **deferred** pending playtesting:
- Factory income buff (MEDIUM priority)
- Outpost upgrade cost adjustment (MEDIUM priority) 
- Starting resource variance (LOW priority)

These will be evaluated after the current changes are playtested.

---

**Working as Pemulis (Systems Dev)**