### PR TITLE
fix: production footer version display (closes #188)

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -62,7 +62,12 @@ jobs:
           az acr login --name ${{ secrets.ACR_NAME }}
           BRANCH_NAME=$(echo "${{ inputs.branch || github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
           TAG="uat-${BRANCH_NAME}-${{ github.sha }}"
-          docker build -t ${{ secrets.ACR_NAME }}.azurecr.io/primal-grid:$TAG .
+          VITE_APP_VERSION=$(node --print "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version")
+          VITE_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          docker build \
+            --build-arg VITE_APP_VERSION="$VITE_APP_VERSION" \
+            --build-arg VITE_BUILD_DATE="$VITE_BUILD_DATE" \
+            -t ${{ secrets.ACR_NAME }}.azurecr.io/primal-grid:$TAG .
           docker push ${{ secrets.ACR_NAME }}.azurecr.io/primal-grid:$TAG
 
       - name: Deploy to UAT Container App

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,12 @@ jobs:
       - name: Build and push image to ACR
         run: |
           az acr login --name ${{ secrets.ACR_NAME }}
-          docker build -t ${{ secrets.ACR_NAME }}.azurecr.io/primal-grid:${{ github.sha }} .
+          VITE_APP_VERSION=$(node --print "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version")
+          VITE_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          docker build \
+            --build-arg VITE_APP_VERSION="$VITE_APP_VERSION" \
+            --build-arg VITE_BUILD_DATE="$VITE_BUILD_DATE" \
+            -t ${{ secrets.ACR_NAME }}.azurecr.io/primal-grid:${{ github.sha }} .
           docker push ${{ secrets.ACR_NAME }}.azurecr.io/primal-grid:${{ github.sha }}
 
       - name: Deploy to Container Apps

--- a/.squad/agents/marathe/history.md
+++ b/.squad/agents/marathe/history.md
@@ -21,6 +21,8 @@
 - Script classifies commits by conventional commit type, strips prefixes for human readability, and groups into prioritized categories (features → fixes → improvements → maintenance)
 - Discord format excludes maintenance/chore/CI commits entirely; markdown format (for PR bodies) includes all categories
 - Script supports `--format discord|markdown` and `--max-lines N` flags for output control
+- Footer build metadata now lives in `client/src/buildMeta.ts` — production reads `import.meta.env.VITE_APP_VERSION` / `VITE_BUILD_DATE` with root `package.json` version as fallback, while local `npm run dev` forces `vdev`
+- Production deployment workflows (`.github/workflows/deploy.yml`, `.github/workflows/deploy-uat.yml`) pass Vite metadata into Docker with `--build-arg VITE_APP_VERSION` and `VITE_BUILD_DATE`, and the `Dockerfile` exports them before `npm run build -w client`
 
 ## 2026-03-10T00:25:00Z: Merge Conflict Resolution in Promotion Workflows (Pemulis)
 

--- a/.squad/decisions/inbox/marathe-vite-build-metadata.md
+++ b/.squad/decisions/inbox/marathe-vite-build-metadata.md
@@ -1,0 +1,26 @@
+## 2026-03-13: Vite Build Metadata for Footer Version
+
+**Author:** Marathe  
+**Issue:** #188  
+**Status:** Accepted
+
+### Decision
+
+Frontend build metadata for the footer should come from Vite environment variables, not `define`-injected globals guarded by `typeof` checks.
+
+- `client/src/buildMeta.ts` reads `import.meta.env.VITE_APP_VERSION` and `import.meta.env.VITE_BUILD_DATE`
+- Production falls back to the root `package.json` version if `VITE_APP_VERSION` is missing
+- Local `npm run dev` always shows `vdev`
+- Deploy workflows must pass `VITE_APP_VERSION` and `VITE_BUILD_DATE` into Docker builds
+
+### Rationale
+
+The previous footer logic depended on `typeof __APP_VERSION__ !== 'undefined'`, which left production bundles able to fall back to `vdev`. Using Vite env metadata makes the production path explicit in CI/CD while keeping local development behavior intentional.
+
+### Implementation Notes
+
+- `.github/workflows/deploy.yml`
+- `.github/workflows/deploy-uat.yml`
+- `Dockerfile`
+- `client/src/buildMeta.ts`
+- `client/src/main.ts`

--- a/.squad/skills/vite-build-metadata/SKILL.md
+++ b/.squad/skills/vite-build-metadata/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: "vite-build-metadata"
+description: "Inject footer/version metadata into Vite builds in CI, Docker, and local dev without leaking dev fallbacks into production"
+domain: "ci-cd"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+
+Use this pattern when frontend code needs immutable build metadata such as version or build date, and the same client bundle is built locally, in Docker, and in GitHub Actions.
+
+## Patterns
+
+### Build metadata module
+
+Create a small client-side module (for example `client/src/buildMeta.ts`) that reads `import.meta.env.VITE_*` values and centralizes the fallback rules.
+
+- In production builds, prefer `import.meta.env.VITE_APP_VERSION`
+- Fall back to the root `package.json` version if the env var is absent
+- In local `npm run dev`, force a clear dev marker like `vdev`
+
+### CI/Docker handoff
+
+Pass the metadata explicitly from workflows into Docker:
+
+- Workflow computes `VITE_APP_VERSION` from root `package.json`
+- Workflow computes `VITE_BUILD_DATE` with `date -u +%Y-%m-%dT%H:%M:%SZ`
+- `docker build` passes both via `--build-arg`
+- `Dockerfile` exports them before `npm run build -w client`
+
+## Examples
+
+- `client/src/buildMeta.ts`
+- `.github/workflows/deploy.yml`
+- `.github/workflows/deploy-uat.yml`
+- `Dockerfile`
+
+## Anti-Patterns
+
+- **`typeof` guards around Vite-injected globals** — they can leave production code on a dev fallback path
+- **Implicit metadata sources** — if CI/CD does not pass build metadata explicitly, production version display becomes harder to reason about and debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Stage 1: Build
 FROM node:22-alpine AS build
 
+ARG VITE_APP_VERSION
+ARG VITE_BUILD_DATE
+
 WORKDIR /app
 
 # Copy package files for dependency installation
@@ -18,7 +21,14 @@ COPY server/ server/
 COPY client/ client/
 
 # Build in dependency order: shared → server → client
-RUN npm run build -w shared && npm run build -w server && npm run build -w client
+RUN if [ -z "$VITE_APP_VERSION" ]; then \
+      VITE_APP_VERSION=$(node --print "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version"); \
+    fi && \
+    if [ -z "$VITE_BUILD_DATE" ]; then \
+      VITE_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ); \
+    fi && \
+    export VITE_APP_VERSION VITE_BUILD_DATE && \
+    npm run build -w shared && npm run build -w server && npm run build -w client
 
 # Stage 2: Production
 FROM node:22-alpine

--- a/client/src/buildMeta.ts
+++ b/client/src/buildMeta.ts
@@ -1,0 +1,12 @@
+import rootPackage from '../../package.json';
+
+type BuildMetaEnv = ImportMetaEnv & {
+  readonly VITE_APP_VERSION?: string;
+  readonly VITE_BUILD_DATE?: string;
+};
+
+const env = import.meta.env as BuildMetaEnv;
+
+export const APP_VERSION = env.DEV ? 'dev' : env.VITE_APP_VERSION || rootPackage.version;
+
+export const BUILD_DATE = env.DEV ? '' : env.VITE_BUILD_DATE || '';

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,6 +1,3 @@
-declare const __APP_VERSION__: string;
-declare const __BUILD_DATE__: string;
-
 import { Application } from 'pixi.js';
 import { Room } from '@colyseus/sdk';
 import { GridRenderer } from './renderer/GridRenderer.js';
@@ -18,6 +15,7 @@ import { LobbyScreen } from './ui/LobbyScreen.js';
 import { WaitingRoom } from './ui/WaitingRoom.js';
 import { UpgradeModal } from './ui/UpgradeModal.js';
 import { EndGameScreen } from './ui/EndGameScreen.js';
+import { APP_VERSION, BUILD_DATE } from './buildMeta.js';
 import { connectToLobby, joinGameRoom, leaveGame, disconnect, onConnectionStatus, isDevMode, getRoom, loadReconnectToken, reconnectGameRoom, resetClient } from './network.js';
 import type { GameLogPayload, GameEndedPayload, PlayerEliminatedPayload } from '@primal-grid/shared';
 import { GAME_ENDED, PLAYER_ELIMINATED, JOIN_GAME } from '@primal-grid/shared';
@@ -378,12 +376,8 @@ bootstrap().catch(console.error);
 (function initFooter() {
   const footer = document.getElementById('app-footer');
   if (!footer) return;
-  const version =
-    typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';
-  const buildDate =
-    typeof __BUILD_DATE__ !== 'undefined'
-      ? new Date(__BUILD_DATE__).toLocaleDateString()
-      : '';
+  const version = APP_VERSION;
+  const buildDate = BUILD_DATE ? new Date(BUILD_DATE).toLocaleDateString() : '';
   const dateStr = buildDate ? ` · Built ${buildDate}` : '';
   footer.innerHTML =
     `v${version}${dateStr} · <a href="https://github.com/dkirby-ms/primal-grid/issues" target="_blank" rel="noopener">Report an Issue</a>`;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,19 +1,7 @@
 import { defineConfig } from 'vite';
-import { readFileSync } from 'fs';
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkg = JSON.parse(
-  readFileSync(resolve(__dirname, '../package.json'), 'utf-8'),
-);
 
 export default defineConfig({
   root: '.',
-  define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
-    __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
-  },
   build: {
     outDir: 'dist',
     target: 'es2022',


### PR DESCRIPTION
Closes #188

Working as Marathe (DevOps / CI-CD)

## Summary
- route footer metadata through `client/src/buildMeta.ts` using `import.meta.env.VITE_APP_VERSION` / `VITE_BUILD_DATE`
- keep `vdev` limited to local `npm run dev`, while production falls back to the root package version if the env is missing
- pass Vite build metadata from `deploy.yml` and `deploy-uat.yml` into Docker, and export it in the `Dockerfile` before the client build

## Validation
- `npm run lint`
- `npm run build -w client`
- `VITE_APP_VERSION=9.9.9 VITE_BUILD_DATE=2026-01-01T00:00:00Z npm run build -w client`
- `docker build --target build --build-arg VITE_APP_VERSION=9.9.9 --build-arg VITE_BUILD_DATE=2026-01-01T00:00:00Z -t primal-grid-issue188-test .`

## Notes
- `npm test` still reports an existing unrelated failure in `server/src/__tests__/map-size-timeout.test.ts` on the 256×256 map case.
